### PR TITLE
improve custom parameter name

### DIFF
--- a/goagen/gen_app/writers.go
+++ b/goagen/gen_app/writers.go
@@ -521,85 +521,85 @@ type {{ .Name }} struct {
 
 */}}{{/* BooleanType */}}{{/*
 */}}{{ $varName := or (and (not .Pointer) .VarName) tempvar }}{{/*
-*/}}{{ tabs .Depth }}if {{ .VarName }}, err2 := strconv.ParseBool(raw{{ goify .Name true }}); err2 == nil {
+*/}}{{ tabs .Depth }}if {{ .VarName }}, err2 := strconv.ParseBool(raw{{ goifyatt .Attribute .Name true }}); err2 == nil {
 {{ if .Pointer }}{{ tabs .Depth }}	{{ $varName }} := &{{ .VarName }}
 {{ end }}{{ tabs .Depth }}	{{ .Pkg }} = {{ $varName }}
 {{ tabs .Depth }}} else {
-{{ tabs .Depth }}	err = goa.MergeErrors(err, goa.InvalidParamTypeError("{{ .Name }}", raw{{ goify .Name true }}, "boolean"))
+{{ tabs .Depth }}	err = goa.MergeErrors(err, goa.InvalidParamTypeError("{{ .Name }}", raw{{ goifyatt .Attribute .Name true }}, "boolean"))
 {{ tabs .Depth }}}
 {{ else if eq .Attribute.Type.Kind 2 }}{{/*
 
 */}}{{/* IntegerType */}}{{/*
 */}}{{ $tmp := tempvar }}{{/*
-*/}}{{ tabs .Depth }}if {{ .VarName }}, err2 := strconv.Atoi(raw{{ goify .Name true }}); err2 == nil {
+*/}}{{ tabs .Depth }}if {{ .VarName }}, err2 := strconv.Atoi(raw{{ goifyatt .Attribute .Name true }}); err2 == nil {
 {{ if .Pointer }}{{ $tmp2 := tempvar }}{{ tabs .Depth }}	{{ $tmp2 }} := {{ .VarName }}
 {{ tabs .Depth }}	{{ $tmp }} := &{{ $tmp2 }}
 {{ tabs .Depth }}	{{ .Pkg }} = {{ $tmp }}
 {{ else }}{{ tabs .Depth }}	{{ .Pkg }} = {{ .VarName }}
 {{ end }}{{ tabs .Depth }}} else {
-{{ tabs .Depth }}	err = goa.MergeErrors(err, goa.InvalidParamTypeError("{{ .Name }}", raw{{ goify .Name true }}, "integer"))
+{{ tabs .Depth }}	err = goa.MergeErrors(err, goa.InvalidParamTypeError("{{ .Name }}", raw{{ goifyatt .Attribute .Name true }}, "integer"))
 {{ tabs .Depth }}}
 {{ else if eq .Attribute.Type.Kind 3 }}{{/*
 
 */}}{{/* NumberType */}}{{/*
 */}}{{ $varName := or (and (not .Pointer) .VarName) tempvar }}{{/*
-*/}}{{ tabs .Depth }}if {{ .VarName }}, err2 := strconv.ParseFloat(raw{{ goify .Name true }}, 64); err2 == nil {
+*/}}{{ tabs .Depth }}if {{ .VarName }}, err2 := strconv.ParseFloat(raw{{ goifyatt .Attribute .Name true }}, 64); err2 == nil {
 {{ if .Pointer }}{{ tabs .Depth }}	{{ $varName }} := &{{ .VarName }}
 {{ end }}{{ tabs .Depth }}	{{ .Pkg }} = {{ $varName }}
 {{ tabs .Depth }}} else {
-{{ tabs .Depth }}	err = goa.MergeErrors(err, goa.InvalidParamTypeError("{{ .Name }}", raw{{ goify .Name true }}, "number"))
+{{ tabs .Depth }}	err = goa.MergeErrors(err, goa.InvalidParamTypeError("{{ .Name }}", raw{{ goifyatt .Attribute .Name true }}, "number"))
 {{ tabs .Depth }}}
 {{ else if eq .Attribute.Type.Kind 4 }}{{/*
 
 */}}{{/* StringType */}}{{/*
-*/}}{{ tabs .Depth }}{{ .Pkg }} = {{ if .Pointer }}&{{ end }}raw{{ goify .Name true }}
+*/}}{{ tabs .Depth }}{{ .Pkg }} = {{ if .Pointer }}&{{ end }}raw{{ goifyatt .Attribute .Name true }}
 {{ else if eq .Attribute.Type.Kind 5 }}{{/*
 
 */}}{{/* DateTimeType */}}{{/*
 */}}{{ $varName := or (and (not .Pointer) .VarName) tempvar }}{{/*
-*/}}{{ tabs .Depth }}if {{ .VarName }}, err2 := time.Parse(time.RFC3339, raw{{ goify .Name true }}); err2 == nil {
+*/}}{{ tabs .Depth }}if {{ .VarName }}, err2 := time.Parse(time.RFC3339, raw{{ goifyatt .Attribute .Name true }}); err2 == nil {
 {{ if .Pointer }}{{ tabs .Depth }}	{{ $varName }} := &{{ .VarName }}
 {{ end }}{{ tabs .Depth }}	{{ .Pkg }} = {{ $varName }}
 {{ tabs .Depth }}} else {
-{{ tabs .Depth }}	err = goa.MergeErrors(err, goa.InvalidParamTypeError("{{ .Name }}", raw{{ goify .Name true }}, "datetime"))
+{{ tabs .Depth }}	err = goa.MergeErrors(err, goa.InvalidParamTypeError("{{ .Name }}", raw{{ goifyatt .Attribute .Name true }}, "datetime"))
 {{ tabs .Depth }}}
 {{ else if eq .Attribute.Type.Kind 6 }}{{/*
 
 */}}{{/* UUIDType */}}{{/*
 */}}{{ $varName := or (and (not .Pointer) .VarName) tempvar }}{{/*
-*/}}{{ tabs .Depth }}if {{ .VarName }}, err2 := uuid.FromString(raw{{ goify .Name true }}); err2 == nil {
+*/}}{{ tabs .Depth }}if {{ .VarName }}, err2 := uuid.FromString(raw{{ goifyatt .Attribute .Name true }}); err2 == nil {
 {{ if .Pointer }}{{ tabs .Depth }}	{{ $varName }} := &{{ .VarName }}
 {{ end }}{{ tabs .Depth }}	{{ .Pkg }} = {{ $varName }}
 {{ tabs .Depth }}} else {
-{{ tabs .Depth }}	err = goa.MergeErrors(err, goa.InvalidParamTypeError("{{ .Name }}", raw{{ goify .Name true }}, "uuid"))
+{{ tabs .Depth }}	err = goa.MergeErrors(err, goa.InvalidParamTypeError("{{ .Name }}", raw{{ goifyatt .Attribute .Name true }}, "uuid"))
 {{ tabs .Depth }}}
 {{ else if eq .Attribute.Type.Kind 7 }}{{/*
 
 */}}{{/* AnyType */}}{{/*
-*/}}{{ if .Pointer }}{{ $tmp := tempvar }}{{ tabs .Depth }}{{ $tmp }} := interface{}(raw{{ goify .Name true }})
+*/}}{{ if .Pointer }}{{ $tmp := tempvar }}{{ tabs .Depth }}{{ $tmp }} := interface{}(raw{{ goifyatt .Attribute .Name true }})
 {{ tabs .Depth }}{{ .Pkg }} = &{{ $tmp }}
-{{ else }}{{ tabs .Depth }}{{ .Pkg }} = raw{{ goify .Name true }}{{/*
+{{ else }}{{ tabs .Depth }}{{ .Pkg }} = raw{{ goifyatt .Attribute .Name true }}{{/*
 */}}{{ end }}
 {{ else if eq .Attribute.Type.Kind 8 }}{{/*
 
 */}}{{/* ArrayType */}}{{/*
-*/}}{{ tabs .Depth }}tmp{{ goify .Name true }} := make({{ valueTypeOf "" .Attribute }}, len(raw{{ goify .Name true }}))
-{{ tabs .Depth }}for i := 0; i < len(raw{{ goify .Name true }}); i++ {
-{{ if eq (arrayAttribute .Attribute).Type.Kind 4 }}{{ tabs .Depth}}	tmp := raw{{ goify .Name true }}[i]{{ else }}{{/*
-*/}}{{ tabs .Depth }}	tmp, err2 := {{ fromString (arrayAttribute .Attribute) (printf "raw%s[i]" (goify .Name true)) }}
+*/}}{{ tabs .Depth }}tmp{{ goifyatt .Attribute .Name true }} := make({{ valueTypeOf "" .Attribute }}, len(raw{{ goifyatt .Attribute .Name true }}))
+{{ tabs .Depth }}for i := 0; i < len(raw{{ goifyatt .Attribute .Name true }}); i++ {
+{{ if eq (arrayAttribute .Attribute).Type.Kind 4 }}{{ tabs .Depth}}	tmp := raw{{ goifyatt .Attribute .Name true }}[i]{{ else }}{{/*
+*/}}{{ tabs .Depth }}	tmp, err2 := {{ fromString (arrayAttribute .Attribute) (printf "raw%s[i]" (goifyatt .Attribute .Name true)) }}
 {{ tabs .Depth }}	if err2 != nil {
-{{ tabs .Depth }}		err = goa.MergeErrors(err, goa.InvalidParamTypeError("{{ .Name }}", raw{{ goify .Name true }}, "{{ valueTypeOf "" .Attribute }}"))
+{{ tabs .Depth }}		err = goa.MergeErrors(err, goa.InvalidParamTypeError("{{ .Name }}", raw{{ goifyatt .Attribute .Name true }}, "{{ valueTypeOf "" .Attribute }}"))
 {{ tabs .Depth }}		break
 {{ tabs .Depth }}	}{{ end }}
-{{ tabs .Depth}}	tmp{{ goify .Name true }}[i] = tmp
+{{ tabs .Depth}}	tmp{{ goifyatt .Attribute .Name true }}[i] = tmp
 {{ tabs .Depth}}}
-{{ tabs .Depth }}{{ .Pkg }} = tmp{{ goify .Name true }}{{/*
+{{ tabs .Depth }}{{ .Pkg }} = tmp{{ goifyatt .Attribute .Name true }}{{/*
 */}}
 {{ else if eq .Attribute.Type.Kind 13 }}{{/*
 
 */}}{{/* FileType */}}{{/*
 */}}{{ tabs .Depth }}if err2 == nil {
-{{ tabs .Depth }}	{{ .Pkg }} = {{ printf "raw%s" (goify .VarName true) }}
+{{ tabs .Depth }}	{{ .Pkg }} = {{ printf "raw%s" (goifyatt .Attribute .Name true) }}
 {{ tabs .Depth }}} else {
 {{ tabs .Depth }}	err = goa.MergeErrors(err, goa.InvalidParamTypeError("{{ .Name }}", "{{ .Name }}", "file"))
 {{ tabs .Depth }}}
@@ -618,20 +618,20 @@ func New{{ .Name }}(ctx context.Context, r *http.Request, service *goa.Service) 
 	req.Request = r
 	rctx := {{ .Name }}{Context: ctx, ResponseData: resp, RequestData: req}{{/*
 */}}
-{{ if .Headers }}{{ range $name, $att := .Headers.Type.ToObject }}	header{{ goify $name true }} := req.Header["{{ canonicalHeaderKey $name }}"]
-{{ $mustValidate := $.Headers.IsRequired $name }}{{ if $mustValidate }}	if len(header{{ goify $name true }}) == 0 {
+{{ if .Headers }}{{ range $name, $att := .Headers.Type.ToObject }}	header{{ goifyatt $att $name true }} := req.Header["{{ canonicalHeaderKey $name }}"]
+{{ $mustValidate := $.Headers.IsRequired $name }}{{ if $mustValidate }}	if len(header{{ goifyatt $att $name true }}) == 0 {
 		err = goa.MergeErrors(err, goa.MissingHeaderError("{{ $name }}"))
 	} else {
-{{ else }}	if len(header{{ goify $name true }}) > 0 {
-{{ end }}{{/* if $mustValidate */}}{{ if $att.Type.IsArray }}		req.Params["{{ $name }}"] = header{{ goify $name true }}
-{{ if eq (arrayAttribute $att).Type.Kind 4 }}		headers := header{{ goify $name true }}
-{{ else }}		headers := make({{ gotypedef $att 2 true false }}, len(header{{ goify $name true }}))
-		for i, raw{{ goify $name true}} := range header{{ goify $name true}} {
+{{ else }}	if len(header{{ goifyatt $att $name true }}) > 0 {
+{{ end }}{{/* if $mustValidate */}}{{ if $att.Type.IsArray }}		req.Params["{{ $name }}"] = header{{ goifyatt $att $name true }}
+{{ if eq (arrayAttribute $att).Type.Kind 4 }}		headers := header{{ goifyatt $att $name true }}
+{{ else }}		headers := make({{ gotypedef $att 2 true false }}, len(header{{ goifyatt $att $name true }}))
+		for i, raw{{ goifyatt $att $name true }} := range header{{ goifyatt $att $name true }} {
 {{ template "Coerce" (newCoerceData $name (arrayAttribute $att) ($.Headers.IsPrimitivePointer $name) "headers[i]" 3) }}{{/*
 */}}		}
 {{ end }}		{{ printf "rctx.%s" (goifyatt $att $name true) }} = headers
-{{ else }}		raw{{ goify $name true}} := header{{ goify $name true}}[0]
-		req.Params["{{ $name }}"] = []string{raw{{ goify $name true }}}
+{{ else }}		raw{{ goifyatt $att $name true }} := header{{ goifyatt $att $name true }}[0]
+		req.Params["{{ $name }}"] = []string{raw{{ goifyatt $att $name true }}}
 {{ template "Coerce" (newCoerceData $name $att ($.Headers.IsPrimitivePointer $name) (printf "rctx.%s" (goifyatt $att $name true)) 2) }}{{ end }}{{/*
 */}}{{ $validation := validationChecker $att ($.Headers.IsNonZero $name) ($.Headers.IsRequired $name) ($.Headers.HasDefaultValue $name) (printf "rctx.%s" (goifyatt $att $name true)) $name 2 false }}{{/*
 */}}{{ if $validation }}{{ $validation }}
@@ -639,22 +639,22 @@ func New{{ .Name }}(ctx context.Context, r *http.Request, service *goa.Service) 
 {{ end }}{{ end }}{{/* if .Headers }}{{/*
 
 */}}{{ if .Params }}{{ range $name, $att := .Params.Type.ToObject }}{{/*
-*/}}	param{{ goify $name true }} := req.Params["{{ $name }}"]
-{{ $mustValidate := $.MustValidate $name }}{{ if $mustValidate }}	if len(param{{ goify $name true }}) == 0 {
+*/}}	param{{ goifyatt $att $name true }} := req.Params["{{ $name }}"]
+{{ $mustValidate := $.MustValidate $name }}{{ if $mustValidate }}	if len(param{{ goifyatt $att $name true }}) == 0 {
 		{{ if $.Params.HasDefaultValue $name }}{{printf "rctx.%s" (goifyatt $att $name true) }} = {{ printVal $att.Type $att.DefaultValue }}{{else}}{{/*
 */}}err = goa.MergeErrors(err, goa.MissingParamError("{{ $name }}")){{end}}
 	} else {
-{{ else }}{{ if $.Params.HasDefaultValue $name }}	if len(param{{ goify $name true }}) == 0 {
+{{ else }}{{ if $.Params.HasDefaultValue $name }}	if len(param{{ goifyatt $att $name true }}) == 0 {
 		{{printf "rctx.%s" (goifyatt $att $name true) }} = {{ printVal $att.Type $att.DefaultValue }}
 	} else {
-{{ else }}	if len(param{{ goify $name true }}) > 0 {
-{{ end }}{{ end }}{{/* if $mustValidate */}}{{ if $att.Type.IsArray }}{{ if eq (arrayAttribute $att).Type.Kind 4 }}		params := param{{ goify $name true }}
-{{ else }}		params := make({{ gotypedef $att 2 true false }}, len(param{{ goify $name true }}))
-		for i, raw{{ goify $name true}} := range param{{ goify $name true}} {
+{{ else }}	if len(param{{ goifyatt $att $name true }}) > 0 {
+{{ end }}{{ end }}{{/* if $mustValidate */}}{{ if $att.Type.IsArray }}{{ if eq (arrayAttribute $att).Type.Kind 4 }}		params := param{{ goifyatt $att $name true }}
+{{ else }}		params := make({{ gotypedef $att 2 true false }}, len(param{{ goifyatt $att $name true }}))
+		for i, raw{{ goifyatt $att $name true }} := range param{{ goifyatt $att $name true }} {
 {{ template "Coerce" (newCoerceData $name (arrayAttribute $att) ($.Params.IsPrimitivePointer $name) "params[i]" 3) }}{{/*
 */}}		}
 {{ end }}		{{ printf "rctx.%s" (goifyatt $att $name true) }} = params
-{{ else }}		raw{{ goify $name true}} := param{{ goify $name true}}[0]
+{{ else }}		raw{{ goifyatt $att $name true }} := param{{ goifyatt $att $name true }}[0]
 {{ template "Coerce" (newCoerceData $name $att ($.Params.IsPrimitivePointer $name) (printf "rctx.%s" (goifyatt $att $name true)) 2) }}{{ end }}{{/*
 */}}{{ if $att.Type.IsArray }}{{ $validation := validationChecker (arrayAttribute $att) true true false "param" (printf "%s[0]" $name) 2 false }}{{/*
 */}}{{ if $validation }}for _, param := range {{ printf "rctx.%s" (goifyatt $att $name true) }} {

--- a/goagen/gen_app/writers_test.go
+++ b/goagen/gen_app/writers_test.go
@@ -2342,15 +2342,15 @@ func NewListBottleContext(ctx context.Context, r *http.Request, service *goa.Ser
 	req := goa.ContextRequest(ctx)
 	req.Request = r
 	rctx := ListBottleContext{Context: ctx, ResponseData: resp, RequestData: req}
-	paramInt := req.Params["int"]
-	if len(paramInt) > 0 {
-		rawInt := paramInt[0]
-		if int_, err2 := strconv.Atoi(rawInt); err2 == nil {
+	paramCustom := req.Params["int"]
+	if len(paramCustom) > 0 {
+		rawCustom := paramCustom[0]
+		if int_, err2 := strconv.Atoi(rawCustom); err2 == nil {
 			tmp2 := int_
 			tmp1 := &tmp2
 			rctx.Custom = tmp1
 		} else {
-			err = goa.MergeErrors(err, goa.InvalidParamTypeError("int", rawInt, "integer"))
+			err = goa.MergeErrors(err, goa.InvalidParamTypeError("int", rawCustom, "integer"))
 		}
 	}
 	return &rctx, err

--- a/goagen/gen_client/generator.go
+++ b/goagen/gen_client/generator.go
@@ -478,12 +478,14 @@ func (g *Generator) generateActionClient(action *design.ActionDefinition, file *
 
 		// Update closure
 		for _, p := range reqData {
-			names = append(names, p.VarName)
+			name := codegen.GoifyAtt(p.Attribute, p.VarName, false)
+			names = append(names, name)
 			params = append(params, p.VarName+" "+cmdFieldType(p.Attribute.Type, false))
 		}
 		for _, p := range optData {
-			names = append(names, p.VarName)
-			params = append(params, p.VarName+" "+cmdFieldType(p.Attribute.Type, p.Attribute.Type.IsPrimitive()))
+			name := codegen.GoifyAtt(p.Attribute, p.VarName, false)
+			names = append(names, name)
+			params = append(params, name+" "+cmdFieldType(p.Attribute.Type, p.Attribute.Type.IsPrimitive()))
 		}
 		return append(reqData, optData...)
 	}

--- a/goagen/gen_client/generator.go
+++ b/goagen/gen_client/generator.go
@@ -478,14 +478,12 @@ func (g *Generator) generateActionClient(action *design.ActionDefinition, file *
 
 		// Update closure
 		for _, p := range reqData {
-			name := codegen.GoifyAtt(p.Attribute, p.VarName, false)
-			names = append(names, name)
+			names = append(names, p.VarName)
 			params = append(params, p.VarName+" "+cmdFieldType(p.Attribute.Type, false))
 		}
 		for _, p := range optData {
-			name := codegen.GoifyAtt(p.Attribute, p.VarName, false)
-			names = append(names, name)
-			params = append(params, name+" "+cmdFieldType(p.Attribute.Type, p.Attribute.Type.IsPrimitive()))
+			names = append(names, p.VarName)
+			params = append(params, p.VarName+" "+cmdFieldType(p.Attribute.Type, p.Attribute.Type.IsPrimitive()))
 		}
 		return append(reqData, optData...)
 	}
@@ -896,7 +894,7 @@ func initParams(att *design.AttributeDefinition) ([]*paramData, []*paramData) {
 	var reqParamData []*paramData
 	var optParamData []*paramData
 	for n, q := range obj {
-		varName := codegen.Goify(n, false)
+		varName := codegen.GoifyAtt(q, n, false)
 		param := &paramData{
 			Name:      n,
 			VarName:   varName,

--- a/goagen/gen_client/generator.go
+++ b/goagen/gen_client/generator.go
@@ -970,9 +970,9 @@ func (c *Client) {{ $funcName }}(resp *http.Response) ({{ decodegotyperef . .All
 	pathTmpl = `{{ $funcName := printf "%sPath%s" (goify (printf "%s%s" .Route.Parent.Name (title .Route.Parent.Parent.Name)) true) ((or (and .Index (add .Index 1)) "") | printf "%v") }}{{/*
 */}}// {{ $funcName }} computes a request path to the {{ .Route.Parent.Name }} action of {{ .Route.Parent.Parent.Name }}.
 func {{ $funcName }}({{ pathParams .Route }}) string {
-	{{ range $i, $param := .Params }}{{/*
-*/}}{{ toString $param.VarName (printf "param%d" $i) $param.Attribute }}
-	{{ end }}
+	{{- range $i, $param := .Params -}}
+	{{ toString $param.VarName (printf "param%d" $i) $param.Attribute }}{{"\n"}}
+	{{- end -}}
 	return fmt.Sprintf({{ printf "%q" (pathTemplate .Route) }}{{ range $i, $param := .Params }}, {{ printf "param%d" $i }}{{ end }})
 }
 `

--- a/goagen/gen_client/generator_test.go
+++ b/goagen/gen_client/generator_test.go
@@ -675,6 +675,8 @@ var _ = Describe("Generate", func() {
 			content := string(c)
 			Ω(string(content)).Should(ContainSubstring("ShowFoo(ctx context.Context, path string, metaFoo *string)"))
 			Ω(string(content)).Should(ContainSubstring("NewShowFooRequest(ctx context.Context, path string, metaFoo *string)"))
+			Ω(string(content)).Should(ContainSubstring("if metaFoo != nil {"))
+			Ω(string(content)).Should(ContainSubstring("values.Set(\"foo\", *metaFoo)"))
 		})
 	})
 })

--- a/goagen/gen_client/generator_test.go
+++ b/goagen/gen_client/generator_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -24,9 +25,13 @@ var _ = Describe("Generate", func() {
 	var files []string
 	var genErr error
 
-	// FIXME @shogo82148
-	_ = files
-	_ = genErr
+	oldGO111MODULE := os.Getenv("GO111MODULE")
+	BeforeEach(func() {
+		os.Setenv("GO111MODULE", "off")
+	})
+	AfterEach(func() {
+		os.Setenv("GO111MODULE", oldGO111MODULE)
+	})
 
 	BeforeEach(func() {
 		var err error
@@ -53,10 +58,6 @@ var _ = Describe("Generate", func() {
 			userTypesHeader  string
 			mediaTypesHeader string
 		)
-		_ = resourceHeader
-		_ = clientHeader
-		_ = userTypesHeader
-		_ = mediaTypesHeader
 
 		funcs := template.FuncMap{
 			"sep": func() string { return string(os.PathSeparator) },
@@ -119,24 +120,24 @@ var _ = Describe("Generate", func() {
 			userTypesHeader = genHeader(data)
 		})
 
-		// It("generates code generated header", func() {
-		// 	Ω(genErr).Should(BeNil())
-		// 	content, err := ioutil.ReadFile(filepath.Join(outDir, "client", "foo.go"))
-		// 	Ω(err).ShouldNot(HaveOccurred())
-		// 	Ω(string(content)).Should(HavePrefix(resourceHeader))
+		It("generates code generated header", func() {
+			Ω(genErr).Should(BeNil())
+			content, err := ioutil.ReadFile(filepath.Join(outDir, "client", "foo.go"))
+			Ω(err).ShouldNot(HaveOccurred())
+			Ω(string(content)).Should(HavePrefix(resourceHeader))
 
-		// 	content, err = ioutil.ReadFile(filepath.Join(outDir, "client", "client.go"))
-		// 	Ω(err).ShouldNot(HaveOccurred())
-		// 	Ω(string(content)).Should(HavePrefix(clientHeader))
+			content, err = ioutil.ReadFile(filepath.Join(outDir, "client", "client.go"))
+			Ω(err).ShouldNot(HaveOccurred())
+			Ω(string(content)).Should(HavePrefix(clientHeader))
 
-		// 	content, err = ioutil.ReadFile(filepath.Join(outDir, "client", "media_types.go"))
-		// 	Ω(err).ShouldNot(HaveOccurred())
-		// 	Ω(string(content)).Should(HavePrefix(mediaTypesHeader))
+			content, err = ioutil.ReadFile(filepath.Join(outDir, "client", "media_types.go"))
+			Ω(err).ShouldNot(HaveOccurred())
+			Ω(string(content)).Should(HavePrefix(mediaTypesHeader))
 
-		// 	content, err = ioutil.ReadFile(filepath.Join(outDir, "client", "user_types.go"))
-		// 	Ω(err).ShouldNot(HaveOccurred())
-		// 	Ω(string(content)).Should(HavePrefix(userTypesHeader))
-		// })
+			content, err = ioutil.ReadFile(filepath.Join(outDir, "client", "user_types.go"))
+			Ω(err).ShouldNot(HaveOccurred())
+			Ω(string(content)).Should(HavePrefix(userTypesHeader))
+		})
 	})
 
 	Context("with a required UUID header", func() {
@@ -171,15 +172,14 @@ var _ = Describe("Generate", func() {
 			showAct.Routes[0].Parent = showAct
 		})
 
-		// FIXME @shogo82148
-		// It("generates header initialization code that compiles", func() {
-		// 	Ω(genErr).Should(BeNil())
-		// 	Ω(files).Should(HaveLen(9))
-		// 	c, err := ioutil.ReadFile(filepath.Join(outDir, "client", "foo.go"))
-		// 	Ω(err).ShouldNot(HaveOccurred())
-		// 	content := string(c)
-		// 	Ω(content).Should(ContainSubstring("header.Set(\"header_name\", tmp3)\n"))
-		// })
+		It("generates header initialization code that compiles", func() {
+			Ω(genErr).Should(BeNil())
+			Ω(files).Should(HaveLen(9))
+			c, err := ioutil.ReadFile(filepath.Join(outDir, "client", "foo.go"))
+			Ω(err).ShouldNot(HaveOccurred())
+			content := string(c)
+			Ω(content).Should(ContainSubstring("header.Set(\"header_name\", tmp3)\n"))
+		})
 	})
 
 	Context("with querystring params in path", func() {
@@ -218,24 +218,24 @@ var _ = Describe("Generate", func() {
 			showAct.Routes[0].Parent = showAct
 		})
 
-		// 	It("generates path initialization code that uses all defined URL params in proper format", func() {
-		// 		Ω(genErr).Should(BeNil())
-		// 		Ω(files).Should(HaveLen(9))
-		// 		c, err := ioutil.ReadFile(filepath.Join(outDir, "client", "foo.go"))
-		// 		Ω(err).ShouldNot(HaveOccurred())
-		// 		content := string(c)
-		// 		Ω(content).Should(ContainSubstring("func ShowFooPath("))
-		// 		Ω(content).Should(ContainSubstring(`param0 := foo`))
-		// 		Ω(content).Should(ContainSubstring(`tmp2 := make([]string, len(bar))
-		// for i, e := range bar {
-		// 	tmp3 := strconv.Itoa(e)
-		// 	tmp2[i] = tmp3
-		// }
-		// param1 := strings.Join(tmp2, ",")`))
-		// 		Ω(content).Should(ContainSubstring(`param2 := baz.Format(time.RFC3339)`))
-		// 		Ω(content).Should(ContainSubstring(`param3 := bat.String()`))
-		// 		Ω(content).Should(ContainSubstring(`fmt.Sprintf("/foo/%s/bar/%s/baz/%s/bat/%s", param0, param1, param2, param3)`))
-		// 	})
+		It("generates path initialization code that uses all defined URL params in proper format", func() {
+			Ω(genErr).Should(BeNil())
+			Ω(files).Should(HaveLen(9))
+			c, err := ioutil.ReadFile(filepath.Join(outDir, "client", "foo.go"))
+			Ω(err).ShouldNot(HaveOccurred())
+			content := string(c)
+			Ω(content).Should(ContainSubstring("func ShowFooPath("))
+			Ω(content).Should(ContainSubstring(`param0 := foo`))
+			Ω(content).Should(ContainSubstring(`tmp2 := make([]string, len(bar))
+	for i, e := range bar {
+		tmp3 := strconv.Itoa(e)
+		tmp2[i] = tmp3
+	}
+	param1 := strings.Join(tmp2, ",")`))
+			Ω(content).Should(ContainSubstring(`param2 := baz.Format(time.RFC3339)`))
+			Ω(content).Should(ContainSubstring(`param3 := bat.String()`))
+			Ω(content).Should(ContainSubstring(`fmt.Sprintf("/foo/%s/bar/%s/baz/%s/bat/%s", param0, param1, param2, param3)`))
+		})
 	})
 
 	Context("with jsonapi like querystring params", func() {
@@ -274,38 +274,38 @@ var _ = Describe("Generate", func() {
 			showAct.Routes[0].Parent = showAct
 		})
 
-		// 		It("generates param initialization code that uses the param name given in the design", func() {
-		// 			Ω(genErr).Should(BeNil())
-		// 			Ω(files).Should(HaveLen(9))
-		// 			c, err := ioutil.ReadFile(filepath.Join(outDir, "client", "foo.go"))
-		// 			Ω(err).ShouldNot(HaveOccurred())
-		// 			content := string(c)
-		// 			Ω(content).Should(ContainSubstring("func ShowFooPath("))
-		// 			Ω(content).Should(ContainSubstring(`values.Set("fields[foo]", *fieldsFoo)`))
-		// 			Ω(content).Should(ContainSubstring(`	for _, p := range fieldsBar {
-		// 		tmp3 := p
-		// 		values.Add("fields[bar]", tmp3)
-		// 	}
-		// `))
-		// 			Ω(content).Should(ContainSubstring(`	for _, p := range fieldsBaz {
-		// 		tmp5 := strconv.Itoa(p)
-		// 		values.Add("fields[baz]", tmp5)
-		// 	}
-		// `))
-		// 			Ω(content).Should(ContainSubstring(`	tmp4 := fieldsBat.Format(time.RFC3339)
-		// 		values.Set("fields[bat]", tmp4)`))
-		// 		})
+		It("generates param initialization code that uses the param name given in the design", func() {
+			Ω(genErr).Should(BeNil())
+			Ω(files).Should(HaveLen(9))
+			c, err := ioutil.ReadFile(filepath.Join(outDir, "client", "foo.go"))
+			Ω(err).ShouldNot(HaveOccurred())
+			content := string(c)
+			Ω(content).Should(ContainSubstring("func ShowFooPath("))
+			Ω(content).Should(ContainSubstring(`values.Set("fields[foo]", *fieldsFoo)`))
+			Ω(content).Should(ContainSubstring(`	for _, p := range fieldsBar {
+		tmp3 := p
+		values.Add("fields[bar]", tmp3)
+	}
+`))
+			Ω(content).Should(ContainSubstring(`	for _, p := range fieldsBaz {
+		tmp5 := strconv.Itoa(p)
+		values.Add("fields[baz]", tmp5)
+	}
+`))
+			Ω(content).Should(ContainSubstring(`		tmp4 := fieldsBat.Format(time.RFC3339)
+		values.Set("fields[bat]", tmp4)`))
+		})
 
-		// Context("with --notool", func() {
-		// 	BeforeEach(func() {
-		// 		os.Args = append(os.Args, "--notool")
-		// 	})
+		Context("with --notool", func() {
+			BeforeEach(func() {
+				os.Args = append(os.Args, "--notool")
+			})
 
-		// 	It("should not return an error", func() {
-		// 		Ω(genErr).Should(BeNil())
-		// 		Ω(files).Should(HaveLen(5)) // 9, minus 4 entries for tool paths
-		// 	})
-		// })
+			It("should not return an error", func() {
+				Ω(genErr).Should(BeNil())
+				Ω(files).Should(HaveLen(5)) // 9, minus 4 entries for tool paths
+			})
+		})
 	})
 
 	Context("with an action using websocket", func() {
@@ -345,44 +345,42 @@ var _ = Describe("Generate", func() {
 			showAct.Routes[0].Parent = showAct
 		})
 
-		// 		It("generates param initialization code that uses the param name given in the design", func() {
-		// 			Ω(genErr).Should(BeNil())
-		// 			Ω(files).Should(HaveLen(9))
-		// 			c, err := ioutil.ReadFile(filepath.Join(outDir, "client", "foo.go"))
-		// 			Ω(err).ShouldNot(HaveOccurred())
-		// 			content := string(c)
-		// 			Ω(content).Should(ContainSubstring("func ShowFooPath("))
-		// 			Ω(content).Should(ContainSubstring(`values.Set("fields[foo]", *fieldsFoo)
-		// `))
-		// 			Ω(content).Should(ContainSubstring(`	if fieldsBar != nil {
-		// 		for _, p := range fieldsBar {
-		// 			tmp3 := p
-		// 			values.Add("fields[bar]", tmp3)
-		// 		}
-		// 	}
-		// `))
-		// 			Ω(content).Should(ContainSubstring(`	if fieldsBaz != nil {
-		// 		for _, p := range fieldsBaz {
-		// 			tmp5 := strconv.Itoa(p)
-		// 			values.Add("fields[baz]", tmp5)
-		// 		}
-		// 	}
-		// `))
-		// 			Ω(content).Should(ContainSubstring(`	tmp4 := fieldsBat.Format(time.RFC3339)
-		// 		values.Set("fields[bat]", tmp4)
-		// `))
-		// 		})
+		It("generates param initialization code that uses the param name given in the design", func() {
+			Ω(genErr).Should(BeNil())
+			Ω(files).Should(HaveLen(9))
+			c, err := ioutil.ReadFile(filepath.Join(outDir, "client", "foo.go"))
+			Ω(err).ShouldNot(HaveOccurred())
+			content := string(c)
+			Ω(content).Should(ContainSubstring("func ShowFooPath("))
+			Ω(content).Should(ContainSubstring(`values.Set("fields[foo]", *fieldsFoo)`))
+			Ω(content).Should(ContainSubstring(`	if fieldsBar != nil {
+		for _, p := range fieldsBar {
+			tmp3 := p
+			values.Add("fields[bar]", tmp3)
+		}
+	}
+`))
+			Ω(content).Should(ContainSubstring(`	if fieldsBaz != nil {
+		for _, p := range fieldsBaz {
+			tmp5 := strconv.Itoa(p)
+			values.Add("fields[baz]", tmp5)
+		}
+	}
+`))
+			Ω(content).Should(ContainSubstring(`		tmp4 := fieldsBat.Format(time.RFC3339)
+		values.Set("fields[bat]", tmp4)`))
+		})
 
-		// Context("with --notool", func() {
-		// 	BeforeEach(func() {
-		// 		os.Args = append(os.Args, "--notool")
-		// 	})
+		Context("with --notool", func() {
+			BeforeEach(func() {
+				os.Args = append(os.Args, "--notool")
+			})
 
-		// 	It("should not return an error", func() {
-		// 		Ω(genErr).Should(BeNil())
-		// 		Ω(files).Should(HaveLen(5)) // 9, minus 4 entries for tool paths
-		// 	})
-		// })
+			It("should not return an error", func() {
+				Ω(genErr).Should(BeNil())
+				Ω(files).Should(HaveLen(5)) // 9, minus 4 entries for tool paths
+			})
+		})
 	})
 
 	Context("with an action with multiple routes", func() {
@@ -418,38 +416,38 @@ var _ = Describe("Generate", func() {
 			showAct.Routes[1].Parent = showAct
 		})
 
-		// It("generates Path function with unique names", func() {
-		// 	Ω(genErr).Should(BeNil())
-		// 	Ω(files).Should(HaveLen(9))
-		// 	content, err := ioutil.ReadFile(filepath.Join(outDir, "client", "foo.go"))
-		// 	Ω(err).ShouldNot(HaveOccurred())
-		// 	Ω(content).Should(ContainSubstring("func ShowFooPath("))
-		// 	Ω(strings.Count(string(content), "func ShowFooPath(")).Should(Equal(1))
-		// 	Ω(content).Should(ContainSubstring("func ShowFooPath2("))
-		// 	Ω(strings.Count(string(content), "func ShowFooPath2(")).Should(Equal(1))
-		// })
+		It("generates Path function with unique names", func() {
+			Ω(genErr).Should(BeNil())
+			Ω(files).Should(HaveLen(9))
+			content, err := ioutil.ReadFile(filepath.Join(outDir, "client", "foo.go"))
+			Ω(err).ShouldNot(HaveOccurred())
+			Ω(content).Should(ContainSubstring("func ShowFooPath("))
+			Ω(strings.Count(string(content), "func ShowFooPath(")).Should(Equal(1))
+			Ω(content).Should(ContainSubstring("func ShowFooPath2("))
+			Ω(strings.Count(string(content), "func ShowFooPath2(")).Should(Equal(1))
+		})
 
-		// Context("with a file server", func() {
-		// 	BeforeEach(func() {
-		// 		res := design.Design.Resources["foo"]
-		// 		res.FileServers = []*design.FileServerDefinition{
-		// 			{
-		// 				Parent:      res,
-		// 				FilePath:    "/swagger/swagger.json",
-		// 				RequestPath: "/swagger.json",
-		// 			},
-		// 		}
-		// 	})
+		Context("with a file server", func() {
+			BeforeEach(func() {
+				res := design.Design.Resources["foo"]
+				res.FileServers = []*design.FileServerDefinition{
+					{
+						Parent:      res,
+						FilePath:    "/swagger/swagger.json",
+						RequestPath: "/swagger.json",
+					},
+				}
+			})
 
-		// 	It("generates a Download function", func() {
-		// 		Ω(genErr).Should(BeNil())
-		// 		Ω(files).Should(HaveLen(9))
-		// 		content, err := ioutil.ReadFile(filepath.Join(outDir, "client", "foo.go"))
-		// 		Ω(err).ShouldNot(HaveOccurred())
-		// 		Ω(content).Should(ContainSubstring("func (c *Client) DownloadSwaggerJSON("))
-		// 	})
+			It("generates a Download function", func() {
+				Ω(genErr).Should(BeNil())
+				Ω(files).Should(HaveLen(9))
+				content, err := ioutil.ReadFile(filepath.Join(outDir, "client", "foo.go"))
+				Ω(err).ShouldNot(HaveOccurred())
+				Ω(content).Should(ContainSubstring("func (c *Client) DownloadSwaggerJSON("))
+			})
 
-		// })
+		})
 	})
 
 	Context("with an action with security configured", func() {
@@ -500,24 +498,24 @@ var _ = Describe("Generate", func() {
 			showAct.Routes[0].Parent = showAct
 		})
 
-		// It("generates the correct client Fields", func() {
-		// 	Ω(genErr).Should(BeNil())
-		// 	Ω(files).Should(HaveLen(9))
-		// 	content, err := ioutil.ReadFile(filepath.Join(outDir, "client", "client.go"))
-		// 	Ω(err).ShouldNot(HaveOccurred())
-		// 	Ω(content).Should(ContainSubstring("JWT1Signer goaclient.Signer"))
-		// 	Ω(content).Should(ContainSubstring("func (c *Client) SetJWT1Signer(signer goaclient.Signer) {\n	c.JWT1Signer = signer\n}"))
-		// })
+		It("generates the correct client Fields", func() {
+			Ω(genErr).Should(BeNil())
+			Ω(files).Should(HaveLen(9))
+			content, err := ioutil.ReadFile(filepath.Join(outDir, "client", "client.go"))
+			Ω(err).ShouldNot(HaveOccurred())
+			Ω(content).Should(ContainSubstring("JWT1Signer goaclient.Signer"))
+			Ω(content).Should(ContainSubstring("func (c *Client) SetJWT1Signer(signer goaclient.Signer) {\n	c.JWT1Signer = signer\n}"))
+		})
 
-		// It("generates the Signer.Sign call from Action", func() {
-		// 	Ω(genErr).Should(BeNil())
-		// 	Ω(files).Should(HaveLen(9))
-		// 	content, err := ioutil.ReadFile(filepath.Join(outDir, "client", "foo.go"))
-		// 	Ω(err).ShouldNot(HaveOccurred())
-		// 	Ω(content).Should(ContainSubstring(`		if err := c.JWT1Signer.Sign(req); err != nil {
-		// 	return nil, err
-		// }`))
-		// })
+		It("generates the Signer.Sign call from Action", func() {
+			Ω(genErr).Should(BeNil())
+			Ω(files).Should(HaveLen(9))
+			content, err := ioutil.ReadFile(filepath.Join(outDir, "client", "foo.go"))
+			Ω(err).ShouldNot(HaveOccurred())
+			Ω(content).Should(ContainSubstring(`		if err := c.JWT1Signer.Sign(req); err != nil {
+			return nil, err
+		}`))
+		})
 	})
 
 	Context("with an action with a user type payload", func() {
@@ -565,14 +563,13 @@ var _ = Describe("Generate", func() {
 			showAct.Routes[0].Parent = showAct
 		})
 
-		// FIXME @shogo82148
-		// It("generates the user type imports", func() {
-		// 	Ω(genErr).Should(BeNil())
-		// 	Ω(files).Should(HaveLen(9))
-		// 	content, err := ioutil.ReadFile(filepath.Join(outDir, "client", "user_types.go"))
-		// 	Ω(err).ShouldNot(HaveOccurred())
-		// 	Ω(content).Should(ContainSubstring("uuid \"github.com/shogo82148/goa-v1/uuid\""))
-		// })
+		It("generates the user type imports", func() {
+			Ω(genErr).Should(BeNil())
+			Ω(files).Should(HaveLen(9))
+			content, err := ioutil.ReadFile(filepath.Join(outDir, "client", "user_types.go"))
+			Ω(err).ShouldNot(HaveOccurred())
+			Ω(content).Should(ContainSubstring("uuid \"github.com/shogo82148/goa-v1/uuid\""))
+		})
 	})
 
 	Context("with a multipartform action with a user type payload", func() {
@@ -624,14 +621,14 @@ var _ = Describe("Generate", func() {
 			showAct.Routes[0].Parent = showAct
 		})
 
-		// It("treat non-required param as pointer type", func() {
-		// 	Ω(genErr).Should(BeNil())
-		// 	Ω(files).Should(HaveLen(9))
-		// 	content, err := ioutil.ReadFile(filepath.Join(outDir, "client", "foo.go"))
-		// 	Ω(err).ShouldNot(HaveOccurred())
-		// 	Ω(string(content)).Should(ContainSubstring("tmp_Param := *payload.Param"))
-		// 	Ω(string(content)).Should(ContainSubstring("tmp_UUID := payload.UUID"))
-		// })
+		It("treat non-required param as pointer type", func() {
+			Ω(genErr).Should(BeNil())
+			Ω(files).Should(HaveLen(9))
+			content, err := ioutil.ReadFile(filepath.Join(outDir, "client", "foo.go"))
+			Ω(err).ShouldNot(HaveOccurred())
+			Ω(string(content)).Should(ContainSubstring("tmp_Param := *payload.Param"))
+			Ω(string(content)).Should(ContainSubstring("tmp_UUID := payload.UUID"))
+		})
 	})
 })
 


### PR DESCRIPTION
currently, `struct:field:name` metadata doesn't change the parameter names of the client methods.
this pull request fixes it.