### PR TITLE
ignore http.ErrMissingFile when checking errors in unmarshal method

### DIFF
--- a/goagen/gen_app/generator.go
+++ b/goagen/gen_app/generator.go
@@ -245,6 +245,7 @@ func (g *Generator) generateControllers() (err error) {
 		codegen.SimpleImport("strconv"),
 		codegen.SimpleImport("time"),
 		codegen.NewImport("uuid", "github.com/gofrs/uuid"),
+		codegen.SimpleImport("errors"),
 	}
 	encoders, err := BuildEncoders(g.API.Produces, true)
 	if err != nil {

--- a/goagen/gen_app/writers.go
+++ b/goagen/gen_app/writers.go
@@ -600,7 +600,7 @@ type {{ .Name }} struct {
 */}}{{/* FileType */}}{{/*
 */}}{{ tabs .Depth }}if err2 == nil {
 {{ tabs .Depth }}	{{ .Pkg }} = {{ printf "raw%s" (goifyatt .Attribute .Name true) }}
-{{ tabs .Depth }}} else if !errors.Is(err, http.ErrMissingFile) {
+{{ tabs .Depth }}} else if !errors.Is(err2, http.ErrMissingFile) {
 {{ tabs .Depth }}	err = goa.MergeErrors(err, goa.InvalidParamTypeError("{{ .Name }}", "{{ .Name }}", "file"))
 {{ tabs .Depth }}}
 {{ end }}`

--- a/goagen/gen_app/writers.go
+++ b/goagen/gen_app/writers.go
@@ -600,7 +600,7 @@ type {{ .Name }} struct {
 */}}{{/* FileType */}}{{/*
 */}}{{ tabs .Depth }}if err2 == nil {
 {{ tabs .Depth }}	{{ .Pkg }} = {{ printf "raw%s" (goifyatt .Attribute .Name true) }}
-{{ tabs .Depth }}} else {
+{{ tabs .Depth }}} else if !errors.Is(err, http.ErrMissingFile) {
 {{ tabs .Depth }}	err = goa.MergeErrors(err, goa.InvalidParamTypeError("{{ .Name }}", "{{ .Name }}", "file"))
 {{ tabs .Depth }}}
 {{ end }}`

--- a/goagen/gen_app/writers_test.go
+++ b/goagen/gen_app/writers_test.go
@@ -2420,7 +2420,7 @@ func unmarshalListBottlePayload(ctx context.Context, service *goa.Service, req *
 	_, rawIcon, err2 := req.FormFile("icon")
 	if err2 == nil {
 		payload.Icon = rawIcon
-	} else {
+	} else if !errors.Is(err2, http.ErrMissingFile) {
 		err = goa.MergeErrors(err, goa.InvalidParamTypeError("icon", "icon", "file"))
 	}`
 


### PR DESCRIPTION
Currently, an optional File DataType (supported in #26) doesn't work as an optional parameter, auto-generated unmarshal method always returns `goa.InvalidParamTypeError`.
This PR fixes it.