### PR TITLE
AWS X-Ray middleware is deprecated

### DIFF
--- a/middleware/xray/middleware.go
+++ b/middleware/xray/middleware.go
@@ -62,6 +62,8 @@ const (
 //   - 1.4 hours:   14 KB
 //
 // Besides those varying size limitations, a trace may be open for up to 7 days.
+//
+// DEPRECATED: please use official AWS X-Ray SDK https://github.com/aws/aws-xray-sdk-go
 func New(service, daemon string) (goa.Middleware, error) {
 	connection, err := periodicallyRedialingConn(context.Background(), time.Minute, func() (net.Conn, error) {
 		return net.Dial("udp", daemon)

--- a/middleware/xray/middleware_test.go
+++ b/middleware/xray/middleware_test.go
@@ -24,6 +24,8 @@ const (
 )
 
 func TestNew(t *testing.T) {
+	t.Skip("xray middleware is deprecated")
+
 	cases := map[string]struct {
 		Daemon  string
 		Success bool
@@ -46,6 +48,8 @@ func TestNew(t *testing.T) {
 }
 
 func TestMiddleware(t *testing.T) {
+	t.Skip("xray middleware is deprecated")
+
 	type (
 		Tra struct {
 			TraceID, SpanID, ParentID string

--- a/middleware/xray/segment_test.go
+++ b/middleware/xray/segment_test.go
@@ -11,11 +11,13 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/shogo82148/goa-v1"
 	"github.com/pkg/errors"
+	"github.com/shogo82148/goa-v1"
 )
 
 func TestRecordError(t *testing.T) {
+	t.Skip("xray middleware is deprecated")
+
 	var (
 		errMsg       = "foo"
 		cause        = "cause"
@@ -50,6 +52,8 @@ func TestRecordError(t *testing.T) {
 }
 
 func TestRecordResponse(t *testing.T) {
+	t.Skip("xray middleware is deprecated")
+
 	type Res struct {
 		Status int
 		Body   string
@@ -105,6 +109,8 @@ func TestRecordResponse(t *testing.T) {
 }
 
 func TestRecordRequest(t *testing.T) {
+	t.Skip("xray middleware is deprecated")
+
 	var (
 		method     = "GET"
 		ip         = "104.18.42.42"
@@ -180,6 +186,8 @@ func TestRecordRequest(t *testing.T) {
 }
 
 func TestSegment_NewSubsegment(t *testing.T) {
+	t.Skip("xray middleware is deprecated")
+
 	conn, err := net.Dial("udp", udplisten)
 	if err != nil {
 		t.Fatalf("failed to connect to daemon - %s", err)
@@ -214,6 +222,8 @@ func TestSegment_NewSubsegment(t *testing.T) {
 }
 
 func TestSegment_SubmitInProgress(t *testing.T) {
+	t.Skip("xray middleware is deprecated")
+
 	t.Run("call twice then close -- second call is ignored", func(t *testing.T) {
 		conn, err := net.Dial("udp", udplisten)
 		if err != nil {
@@ -281,6 +291,8 @@ func TestSegment_SubmitInProgress(t *testing.T) {
 // TestRace starts two goroutines and races them to call Segment's public function. In this way, when tests are run
 // with the -race flag, race conditions will be detected.
 func TestRace(t *testing.T) {
+	t.Skip("xray middleware is deprecated")
+
 	var (
 		rErr   = errors.New("oh no")
 		req, _ = http.NewRequest("GET", "https://goa.design", nil)

--- a/middleware/xray/transport_test.go
+++ b/middleware/xray/transport_test.go
@@ -22,6 +22,8 @@ func (mrt *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error
 }
 
 func TestTransportExample(t *testing.T) {
+	t.Skip("xray middleware is deprecated")
+
 	var (
 		responseBody = "good morning"
 	)
@@ -90,6 +92,8 @@ func TestTransportExample(t *testing.T) {
 }
 
 func TestTransportNoSegmentInContext(t *testing.T) {
+	t.Skip("xray middleware is deprecated")
+
 	var (
 		url, _ = url.Parse("https://goa.design/path?query#fragment")
 		req, _ = http.NewRequest("GET", url.String(), nil)
@@ -112,6 +116,8 @@ func TestTransportNoSegmentInContext(t *testing.T) {
 }
 
 func TestTransport(t *testing.T) {
+	t.Skip("xray middleware is deprecated")
+
 	type (
 		Tra struct {
 			TraceID, SpanID string

--- a/middleware/xray/wrap_doer_test.go
+++ b/middleware/xray/wrap_doer_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestWrapDoer(t *testing.T) {
+	t.Skip("xray middleware is deprecated")
+
 	RegisterTestingT(t)
 
 	var (


### PR DESCRIPTION
there is official AWS X-Ray SDK, so I will not maintain this middleware.
please use https://github.com/aws/aws-xray-sdk-go instead of it.