### PR TITLE
functions in **_testing.go are test helper functions

### DIFF
--- a/goagen/gen_app/test_generator.go
+++ b/goagen/gen_app/test_generator.go
@@ -366,6 +366,8 @@ func {{ $test.Name }}(t goatest.TInterface, ctx context.Context, service *goa.Se
 */}}{{ range $header := $test.Headers }}, {{ $header.Name }} {{ $header.Pointer }}{{ $header.Type }}{{ end }}{{/*
 */}}{{ if $test.Payload }}, {{ $test.Payload.Name }} {{ $test.Payload.Pointer }}{{ $test.Payload.Type }}{{ end }}){{/*
 */}} (http.ResponseWriter{{ if $test.ReturnType }}, {{ $test.ReturnType.Pointer }}{{ $test.ReturnType.Type }}{{ end }}) {
+	t.Helper()
+
 	// Setup service
 	var (
 		{{ $logBuf := $test.Escape "logBuf" }}{{ $logBuf }} bytes.Buffer

--- a/goagen/gen_app/test_generator.go
+++ b/goagen/gen_app/test_generator.go
@@ -370,7 +370,7 @@ func {{ $test.Name }}(t goatest.TInterface, ctx context.Context, service *goa.Se
 
 	// Setup service
 	var (
-		{{ $logBuf := $test.Escape "logBuf" }}{{ $logBuf }} bytes.Buffer
+		{{ $logBuf := $test.Escape "logBuf" }}{{ $logBuf }} strings.Builder
 		{{ $resp := $test.Escape "resp" }}{{ if $test.ReturnType }}{{ $resp }}   interface{}{{ end }}
 
 		{{ $respSetter := $test.Escape "respSetter" }}{{ $respSetter }} goatest.ResponseSetterFunc = func(r interface{}) { {{ if $test.ReturnType }}{{ $resp }} = r{{ end }} }

--- a/goatest/testing.go
+++ b/goatest/testing.go
@@ -1,7 +1,6 @@
 package goatest
 
 import (
-	"bytes"
 	"io"
 	"log"
 	"testing"
@@ -25,7 +24,7 @@ func (r ResponseSetterFunc) Encode(v interface{}) error {
 }
 
 // Service provide a general goa.Service used for testing purposes
-func Service(logBuf *bytes.Buffer, respSetter ResponseSetterFunc) *goa.Service {
+func Service(logBuf io.Writer, respSetter ResponseSetterFunc) *goa.Service {
 	s := goa.New("test")
 	logger := log.New(logBuf, "", log.Ltime)
 	s.WithLogger(goa.NewLogger(logger))

--- a/goatest/testing.go
+++ b/goatest/testing.go
@@ -4,16 +4,16 @@ import (
 	"bytes"
 	"io"
 	"log"
+	"testing"
 
 	"github.com/shogo82148/goa-v1"
 	"github.com/shogo82148/goa-v1/middleware"
 )
 
-// TInterface is an interface for go's testing.T
-type TInterface interface {
-	Errorf(format string, args ...interface{})
-	Fatalf(format string, args ...interface{})
-}
+// TInterface is an interface for Go's testing.T and testing.B.
+//
+// It is an alias of testing.TB.
+type TInterface = testing.TB
 
 // ResponseSetterFunc func
 type ResponseSetterFunc func(resp interface{})


### PR DESCRIPTION
functions in `**_testing.go` are called from testing codes many times over,
and [t.Errorf](https://golang.org/pkg/testing/#T.Errorf) prints their file and line information.
It make difficult to read the error log.

```
TestFoo: foo_testing.go:388: invalid response media type
```

This pull request resolve it by adding [t.Helper](https://golang.org/pkg/testing/#T.Helper) into these functions.