### PR TITLE
Add warning logger method

### DIFF
--- a/logging.go
+++ b/logging.go
@@ -113,6 +113,17 @@ func LogInfo(ctx context.Context, msg string, keyvals ...interface{}) {
 	}
 }
 
+// LogWarn extracts the logger from the given context and calls Warn on it.
+// This is intended for code that needs portable logging such as the internal code of goa and
+// middleware. User code should use the log adapters instead.
+func LogWarn(ctx context.Context, msg string, keyvals ...interface{}) {
+	if l := ctx.Value(logKey); l != nil {
+		if logger, ok := l.(LogAdapter); ok {
+			logger.Warn(msg, keyvals...)
+		}
+	}
+}
+
 // LogError extracts the logger from the given context and calls Error on it.
 // This is intended for code that needs portable logging such as the internal code of goa and
 // middleware. User code should use the log adapters instead.

--- a/logging.go
+++ b/logging.go
@@ -19,6 +19,8 @@ type (
 	LogAdapter interface {
 		// Info logs an informational message.
 		Info(msg string, keyvals ...interface{})
+		// Warn logs a warning message.
+		Warn(mgs string, keyvals ...interface{})
 		// Error logs an error.
 		Error(msg string, keyvals ...interface{})
 		// New appends to the logger context and returns the updated logger logger.
@@ -47,11 +49,15 @@ func Logger(ctx context.Context) *log.Logger {
 }
 
 func (a *adapter) Info(msg string, keyvals ...interface{}) {
-	a.logit(msg, keyvals, false)
+	a.logit(msg, keyvals, "INFO")
+}
+
+func (a *adapter) Warn(msg string, keyvals ...interface{}) {
+	a.logit(msg, keyvals, "WARN")
 }
 
 func (a *adapter) Error(msg string, keyvals ...interface{}) {
-	a.logit(msg, keyvals, true)
+	a.logit(msg, keyvals, "EROR")
 }
 
 func (a *adapter) New(keyvals ...interface{}) LogAdapter {
@@ -70,7 +76,7 @@ func (a *adapter) New(keyvals ...interface{}) LogAdapter {
 	}
 }
 
-func (a *adapter) logit(msg string, keyvals []interface{}, iserror bool) {
+func (a *adapter) logit(msg string, keyvals []interface{}, level string) {
 	n := (len(keyvals) + 1) / 2
 	if len(keyvals)%2 != 0 {
 		keyvals = append(keyvals, ErrMissingLogValue)
@@ -78,11 +84,7 @@ func (a *adapter) logit(msg string, keyvals []interface{}, iserror bool) {
 	m := (len(a.keyvals) + 1) / 2
 	n += m
 	var fm bytes.Buffer
-	lvl := "INFO"
-	if iserror {
-		lvl = "EROR"
-	}
-	fm.WriteString(fmt.Sprintf("[%s] %s", lvl, msg))
+	fm.WriteString(fmt.Sprintf("[%s] %s", level, msg))
 	vals := make([]interface{}, n)
 	offset := len(a.keyvals)
 	for i := 0; i < offset; i += 2 {

--- a/logging/kit/adapter.go
+++ b/logging/kit/adapter.go
@@ -47,6 +47,13 @@ func (a *adapter) Info(msg string, data ...interface{}) {
 	a.Logger.Log(ctx...)
 }
 
+// Info logs warning messages using go-kit.
+func (a *adapter) Warn(msg string, data ...interface{}) {
+	ctx := []interface{}{"lvl", "warn", "msg", msg}
+	ctx = append(ctx, data...)
+	a.Logger.Log(ctx...)
+}
+
 // Error logs error messages using go-kit.
 func (a *adapter) Error(msg string, data ...interface{}) {
 	ctx := []interface{}{"lvl", "error", "msg", msg}

--- a/logging/kit/adapter_test.go
+++ b/logging/kit/adapter_test.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 
 	"github.com/go-kit/kit/log"
-	"github.com/shogo82148/goa-v1"
-	goakit "github.com/shogo82148/goa-v1/logging/kit"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/shogo82148/goa-v1"
+	goakit "github.com/shogo82148/goa-v1/logging/kit"
 )
 
 var _ = Describe("New", func() {
@@ -16,6 +16,7 @@ var _ = Describe("New", func() {
 	var adapter goa.LogAdapter
 
 	BeforeEach(func() {
+		buf.Reset()
 		logger = log.NewLogfmtLogger(&buf)
 		adapter = goakit.New(logger)
 	})
@@ -24,5 +25,17 @@ var _ = Describe("New", func() {
 		msg := "msg"
 		adapter.Info(msg)
 		Ω(buf.String()).Should(Equal("lvl=info msg=" + msg + "\n"))
+	})
+
+	It("creates an adapter that logs", func() {
+		msg := "msg"
+		adapter.Warn(msg)
+		Ω(buf.String()).Should(Equal("lvl=warn msg=" + msg + "\n"))
+	})
+
+	It("creates an adapter that logs", func() {
+		msg := "msg"
+		adapter.Error(msg)
+		Ω(buf.String()).Should(Equal("lvl=error msg=" + msg + "\n"))
 	})
 })

--- a/logging/kit/adapter_test.go
+++ b/logging/kit/adapter_test.go
@@ -28,6 +28,7 @@ var _ = Describe("New", func() {
 	})
 
 	It("creates an adapter that logs", func() {
+		adapter := adapter.(goa.WarningLogAdapter)
 		msg := "msg"
 		adapter.Warn(msg)
 		Ω(buf.String()).Should(Equal("lvl=warn msg=" + msg + "\n"))

--- a/logging/log15/adapter.go
+++ b/logging/log15/adapter.go
@@ -16,8 +16,8 @@ package goalog15
 import (
 	"context"
 
-	"github.com/shogo82148/goa-v1"
 	"github.com/inconshreveable/log15"
+	"github.com/shogo82148/goa-v1"
 )
 
 // adapter is the log15 goa adapter logger.
@@ -42,6 +42,11 @@ func Logger(ctx context.Context) log15.Logger {
 // Info logs informational messages using log15.
 func (a *adapter) Info(msg string, data ...interface{}) {
 	a.Logger.Info(msg, data...)
+}
+
+// Warn logs informational messages using log15.
+func (a *adapter) Warn(msg string, data ...interface{}) {
+	a.Logger.Warn(msg, data...)
 }
 
 // Error logs error messages using log15.

--- a/logging/log15/adapter_test.go
+++ b/logging/log15/adapter_test.go
@@ -39,6 +39,7 @@ var _ = Describe("New", func() {
 	})
 
 	It("creates an adapter that logs", func() {
+		adapter := adapter.(goa.WarningLogAdapter)
 		msg := "msg"
 		adapter.Warn(msg)
 		Ω(handler.records).Should(HaveLen(1))

--- a/logging/log15/adapter_test.go
+++ b/logging/log15/adapter_test.go
@@ -3,11 +3,11 @@ package goalog15_test
 import (
 	"context"
 
-	"github.com/shogo82148/goa-v1"
-	goalog15 "github.com/shogo82148/goa-v1/logging/log15"
 	"github.com/inconshreveable/log15"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/shogo82148/goa-v1"
+	goalog15 "github.com/shogo82148/goa-v1/logging/log15"
 )
 
 type TestHandler struct {
@@ -34,6 +34,20 @@ var _ = Describe("New", func() {
 	It("creates an adapter that logs", func() {
 		msg := "msg"
 		adapter.Info(msg)
+		Ω(handler.records).Should(HaveLen(1))
+		Ω(handler.records[0].Msg).Should(ContainSubstring(msg))
+	})
+
+	It("creates an adapter that logs", func() {
+		msg := "msg"
+		adapter.Warn(msg)
+		Ω(handler.records).Should(HaveLen(1))
+		Ω(handler.records[0].Msg).Should(ContainSubstring(msg))
+	})
+
+	It("creates an adapter that logs", func() {
+		msg := "msg"
+		adapter.Error(msg)
 		Ω(handler.records).Should(HaveLen(1))
 		Ω(handler.records[0].Msg).Should(ContainSubstring(msg))
 	})

--- a/logging/logrus/adapter.go
+++ b/logging/logrus/adapter.go
@@ -51,6 +51,11 @@ func (a *adapter) Info(msg string, data ...interface{}) {
 	a.Entry.WithFields(data2rus(data)).Info(msg)
 }
 
+// Warn logs message using logrus.
+func (a *adapter) Warn(msg string, data ...interface{}) {
+	a.Entry.WithFields(data2rus(data)).Warn(msg)
+}
+
 // Error logs errors using logrus.
 func (a *adapter) Error(msg string, data ...interface{}) {
 	a.Entry.WithFields(data2rus(data)).Error(msg)

--- a/logging/logrus/adapter_test.go
+++ b/logging/logrus/adapter_test.go
@@ -5,10 +5,10 @@ import (
 
 	"context"
 
-	"github.com/shogo82148/goa-v1"
-	goalogrus "github.com/shogo82148/goa-v1/logging/logrus"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/shogo82148/goa-v1"
+	goalogrus "github.com/shogo82148/goa-v1/logging/logrus"
 	"github.com/sirupsen/logrus"
 )
 
@@ -26,6 +26,18 @@ var _ = Describe("goalogrus", func() {
 	It("adapts info messages", func() {
 		msg := "msg"
 		adapter.Info(msg)
+		Ω(buf.String()).Should(ContainSubstring(msg))
+	})
+
+	It("adapts warn messages", func() {
+		msg := "msg"
+		adapter.Warn(msg)
+		Ω(buf.String()).Should(ContainSubstring(msg))
+	})
+
+	It("adapts error messages", func() {
+		msg := "msg"
+		adapter.Error(msg)
 		Ω(buf.String()).Should(ContainSubstring(msg))
 	})
 })

--- a/logging/logrus/adapter_test.go
+++ b/logging/logrus/adapter_test.go
@@ -30,6 +30,7 @@ var _ = Describe("goalogrus", func() {
 	})
 
 	It("adapts warn messages", func() {
+		adapter := adapter.(goa.WarningLogAdapter)
 		msg := "msg"
 		adapter.Warn(msg)
 		Ω(buf.String()).Should(ContainSubstring(msg))

--- a/logging_test.go
+++ b/logging_test.go
@@ -45,6 +45,11 @@ var _ = Describe("LogAdapter", func() {
 			Ω(out.String()).Should(ContainSubstring(msg + " data=foo"))
 		})
 
+		It("Warn logs", func() {
+			logger.Warn(msg, data...)
+			Ω(out.String()).Should(ContainSubstring(msg + " data=foo"))
+		})
+
 		It("Error logs", func() {
 			logger.Error(msg, data...)
 			Ω(out.String()).Should(ContainSubstring(msg + " data=foo"))

--- a/logging_test.go
+++ b/logging_test.go
@@ -6,15 +6,23 @@ import (
 
 	"context"
 
-	"github.com/shogo82148/goa-v1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/shogo82148/goa-v1"
 )
 
 var _ = Describe("Info", func() {
 	Context("with a nil Log", func() {
 		It("doesn't log and doesn't crash", func() {
 			Ω(func() { goa.LogInfo(context.Background(), "foo", "bar") }).ShouldNot(Panic())
+		})
+	})
+})
+
+var _ = Describe("Warn", func() {
+	Context("with a nil Log", func() {
+		It("doesn't log and doesn't crash", func() {
+			Ω(func() { goa.LogWarn(context.Background(), "foo", "bar") }).ShouldNot(Panic())
 		})
 	})
 })

--- a/logging_test.go
+++ b/logging_test.go
@@ -54,6 +54,7 @@ var _ = Describe("LogAdapter", func() {
 		})
 
 		It("Warn logs", func() {
+			logger := logger.(goa.WarningLogAdapter)
 			logger.Warn(msg, data...)
 			Ω(out.String()).Should(ContainSubstring(msg + " data=foo"))
 		})

--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -32,12 +32,18 @@ type logEntry struct {
 type testLogger struct {
 	Context      []interface{}
 	InfoEntries  []logEntry
+	WarnEntries  []logEntry
 	ErrorEntries []logEntry
 }
 
 func (t *testLogger) Info(msg string, data ...interface{}) {
 	e := logEntry{msg, append(t.Context, data...)}
 	t.InfoEntries = append(t.InfoEntries, e)
+}
+
+func (t *testLogger) Warn(msg string, data ...interface{}) {
+	e := logEntry{msg, append(t.Context, data...)}
+	t.WarnEntries = append(t.InfoEntries, e)
 }
 
 func (t *testLogger) Error(msg string, data ...interface{}) {


### PR DESCRIPTION
Some major logger packages support `WARNING` log level. However, Goa does not currently implement it. I have added the `LogWarn` function, it will log warning messages using any pre-defined log adapter.