### PR TITLE
migrate the ioutil package

### DIFF
--- a/_integration_tests/integration_test.go
+++ b/_integration_tests/integration_test.go
@@ -3,7 +3,6 @@ package tests
 import (
 	"fmt"
 	"go/build"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -30,7 +29,7 @@ func TestDefaultMedia(t *testing.T) {
 	if err := gobuild("./media"); err != nil {
 		t.Error(err.Error())
 	}
-	b, err := ioutil.ReadFile("./media/app/contexts.go")
+	b, err := os.ReadFile("./media/app/contexts.go")
 	if err != nil {
 		t.Fatal("failed to load contexts.go")
 	}
@@ -68,7 +67,7 @@ func TestCustomFieldName(t *testing.T) {
 	if err := gobuild("./field"); err != nil {
 		t.Error(err.Error())
 	}
-	b, err := ioutil.ReadFile("./field/app/user_types.go")
+	b, err := os.ReadFile("./field/app/user_types.go")
 	if err != nil {
 		t.Fatal("failed to load user_types.go")
 	}
@@ -87,7 +86,7 @@ type UploadPayload struct {
 		t.Errorf("UploadPayload attribute definitions reference failed. Generated user_types:\n%s", string(b))
 	}
 
-	b, err = ioutil.ReadFile("./field/app/media_types.go")
+	b, err = os.ReadFile("./field/app/media_types.go")
 	if err != nil {
 		t.Fatal("failed to load media_types.go")
 	}

--- a/client/cli.go
+++ b/client/cli.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -22,7 +22,7 @@ import (
 //    500+: 5
 func HandleResponse(c *Client, resp *http.Response, pretty bool) {
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to read body: %s", err)
 		os.Exit(-1)

--- a/client/client.go
+++ b/client/client.go
@@ -6,7 +6,6 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
 	"time"
@@ -188,7 +187,7 @@ func drainBody(b io.ReadCloser) (r1, r2 io.ReadCloser, err error) {
 	if err = b.Close(); err != nil {
 		return nil, nil, err
 	}
-	return ioutil.NopCloser(&buf), ioutil.NopCloser(bytes.NewReader(buf.Bytes())), nil
+	return io.NopCloser(&buf), io.NopCloser(bytes.NewReader(buf.Bytes())), nil
 }
 
 // shortID produces a "unique" 6 bytes long string.

--- a/goagen/codegen/workspace.go
+++ b/goagen/codegen/workspace.go
@@ -9,7 +9,6 @@ import (
 	"go/parser"
 	"go/scanner"
 	"go/token"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -81,7 +80,7 @@ var (
 // NewWorkspace returns a newly created temporary Go workspace.
 // Use Delete to delete the corresponding temporary directory when done.
 func NewWorkspace(prefix string) (*Workspace, error) {
-	dir, err := ioutil.TempDir("", prefix)
+	dir, err := os.MkdirTemp("", prefix)
 	if err != nil {
 		return nil, err
 	}
@@ -294,7 +293,7 @@ func (f *SourceFile) FormatCode() error {
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, f.Abs(), nil, parser.ParseComments)
 	if err != nil {
-		content, _ := ioutil.ReadFile(f.Abs())
+		content, _ := os.ReadFile(f.Abs())
 		var buf bytes.Buffer
 		scanner.PrintError(&buf, err)
 		return fmt.Errorf("%s\n========\nContent:\n%s", buf.String(), content)
@@ -361,7 +360,7 @@ func PackagePath(path string) (string, error) {
 	if os.Getenv("GO111MODULE") != "off" { // Module mode
 		root, file := findModuleRoot(absPath, "", false)
 		if root != "" {
-			content, err := ioutil.ReadFile(filepath.Join(root, file))
+			content, err := os.ReadFile(filepath.Join(root, file))
 			if err == nil {
 				p := modulePath(content)
 				base := filepath.FromSlash(root)

--- a/goagen/codegen/workspace_test.go
+++ b/goagen/codegen/workspace_test.go
@@ -3,7 +3,6 @@ package codegen_test
 import (
 	"fmt"
 	"go/build"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -68,7 +67,7 @@ var _ = Describe("Workspace", func() {
 
 				Context("outside GOPATH", func() {
 					BeforeEach(func() {
-						gopath, err = ioutil.TempDir(".", "go")
+						gopath, err = os.MkdirTemp(".", "go")
 						Ω(err).ShouldNot(HaveOccurred())
 						os.Setenv("GOPATH", gopath)
 					})
@@ -107,7 +106,7 @@ var _ = Describe("Workspace", func() {
 
 				Context("outside GOPATH", func() {
 					BeforeEach(func() {
-						gopath, err = ioutil.TempDir(".", "go")
+						gopath, err = os.MkdirTemp(".", "go")
 						Ω(err).ShouldNot(HaveOccurred())
 						os.Setenv("GOPATH", gopath)
 					})
@@ -144,7 +143,7 @@ var _ = Describe("Workspace", func() {
 
 				Context("outside GOPATH", func() {
 					BeforeEach(func() {
-						gopath, err = ioutil.TempDir(".", "go")
+						gopath, err = os.MkdirTemp(".", "go")
 						Ω(err).ShouldNot(HaveOccurred())
 						os.Setenv("GOPATH", gopath)
 					})
@@ -180,7 +179,7 @@ var _ = Describe("Workspace", func() {
 
 				Context("outside GOPATH", func() {
 					BeforeEach(func() {
-						gopath, err = ioutil.TempDir(".", "go")
+						gopath, err = os.MkdirTemp(".", "go")
 						Ω(err).ShouldNot(HaveOccurred())
 						os.Setenv("GOPATH", gopath)
 					})
@@ -214,7 +213,7 @@ var _ = Describe("Workspace", func() {
 
 				Context("outside GOPATH", func() {
 					BeforeEach(func() {
-						gopath, err = ioutil.TempDir(".", "go")
+						gopath, err = os.MkdirTemp(".", "go")
 						Ω(err).ShouldNot(HaveOccurred())
 						os.Setenv("GOPATH", gopath)
 					})
@@ -248,7 +247,7 @@ var _ = Describe("Workspace", func() {
 
 				Context("outside GOPATH", func() {
 					BeforeEach(func() {
-						gopath, err = ioutil.TempDir(".", "go")
+						gopath, err = os.MkdirTemp(".", "go")
 						Ω(err).ShouldNot(HaveOccurred())
 						os.Setenv("GOPATH", gopath)
 					})
@@ -310,7 +309,7 @@ var _ = Describe("Workspace", func() {
 
 				Context("outside GOPATH", func() {
 					BeforeEach(func() {
-						gopath, err = ioutil.TempDir(".", "go")
+						gopath, err = os.MkdirTemp(".", "go")
 						Ω(err).ShouldNot(HaveOccurred())
 						os.Setenv("GOPATH", gopath)
 					})
@@ -349,7 +348,7 @@ var _ = Describe("Workspace", func() {
 
 				Context("outside GOPATH", func() {
 					BeforeEach(func() {
-						gopath, err = ioutil.TempDir(".", "go")
+						gopath, err = os.MkdirTemp(".", "go")
 						Ω(err).ShouldNot(HaveOccurred())
 						os.Setenv("GOPATH", gopath)
 					})
@@ -386,7 +385,7 @@ var _ = Describe("Workspace", func() {
 
 				Context("outside GOPATH", func() {
 					BeforeEach(func() {
-						gopath, err = ioutil.TempDir(".", "go")
+						gopath, err = os.MkdirTemp(".", "go")
 						Ω(err).ShouldNot(HaveOccurred())
 						os.Setenv("GOPATH", gopath)
 					})
@@ -422,7 +421,7 @@ var _ = Describe("Workspace", func() {
 
 				Context("outside GOPATH", func() {
 					BeforeEach(func() {
-						gopath, err = ioutil.TempDir(".", "go")
+						gopath, err = os.MkdirTemp(".", "go")
 						Ω(err).ShouldNot(HaveOccurred())
 						os.Setenv("GOPATH", gopath)
 					})
@@ -457,7 +456,7 @@ var _ = Describe("Workspace", func() {
 
 				Context("outside GOPATH", func() {
 					BeforeEach(func() {
-						gopath, err = ioutil.TempDir(".", "go")
+						gopath, err = os.MkdirTemp(".", "go")
 						Ω(err).ShouldNot(HaveOccurred())
 						os.Setenv("GOPATH", gopath)
 					})
@@ -492,7 +491,7 @@ var _ = Describe("Workspace", func() {
 
 				Context("outside GOPATH", func() {
 					BeforeEach(func() {
-						gopath, err = ioutil.TempDir(".", "go")
+						gopath, err = os.MkdirTemp(".", "go")
 						Ω(err).ShouldNot(HaveOccurred())
 						os.Setenv("GOPATH", gopath)
 					})
@@ -540,7 +539,7 @@ var _ = Describe("Workspace", func() {
 
 		Context("outside GOPATH", func() {
 			BeforeEach(func() {
-				gopath, err = ioutil.TempDir(".", "go")
+				gopath, err = os.MkdirTemp(".", "go")
 				Ω(err).ShouldNot(HaveOccurred())
 				os.Setenv("GOPATH", gopath)
 			})
@@ -603,7 +602,7 @@ var _ = Describe("Workspace", func() {
 
 				Context("outside GOPATH", func() {
 					BeforeEach(func() {
-						gopath, err = ioutil.TempDir(".", "go")
+						gopath, err = os.MkdirTemp(".", "go")
 						Ω(err).ShouldNot(HaveOccurred())
 						os.Setenv("GOPATH", gopath)
 					})
@@ -642,7 +641,7 @@ var _ = Describe("Workspace", func() {
 
 				Context("outside GOPATH", func() {
 					BeforeEach(func() {
-						gopath, err = ioutil.TempDir(".", "go")
+						gopath, err = os.MkdirTemp(".", "go")
 						Ω(err).ShouldNot(HaveOccurred())
 						os.Setenv("GOPATH", gopath)
 					})
@@ -679,7 +678,7 @@ var _ = Describe("Workspace", func() {
 
 				Context("outside GOPATH", func() {
 					BeforeEach(func() {
-						gopath, err = ioutil.TempDir(".", "go")
+						gopath, err = os.MkdirTemp(".", "go")
 						Ω(err).ShouldNot(HaveOccurred())
 						os.Setenv("GOPATH", gopath)
 					})
@@ -715,7 +714,7 @@ var _ = Describe("Workspace", func() {
 
 				Context("outside GOPATH", func() {
 					BeforeEach(func() {
-						gopath, err = ioutil.TempDir(".", "go")
+						gopath, err = os.MkdirTemp(".", "go")
 						Ω(err).ShouldNot(HaveOccurred())
 						os.Setenv("GOPATH", gopath)
 					})
@@ -750,7 +749,7 @@ var _ = Describe("Workspace", func() {
 
 				Context("outside GOPATH", func() {
 					BeforeEach(func() {
-						gopath, err = ioutil.TempDir(".", "go")
+						gopath, err = os.MkdirTemp(".", "go")
 						Ω(err).ShouldNot(HaveOccurred())
 						os.Setenv("GOPATH", gopath)
 					})
@@ -785,7 +784,7 @@ var _ = Describe("Workspace", func() {
 
 				Context("outside GOPATH", func() {
 					BeforeEach(func() {
-						gopath, err = ioutil.TempDir(".", "go")
+						gopath, err = os.MkdirTemp(".", "go")
 						Ω(err).ShouldNot(HaveOccurred())
 						os.Setenv("GOPATH", gopath)
 					})

--- a/goagen/gen_app/generator_test.go
+++ b/goagen/gen_app/generator_test.go
@@ -2,7 +2,6 @@ package genapp_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -30,7 +29,7 @@ var _ = Describe("Generate", func() {
 		var err error
 		workspace, err = codegen.NewWorkspace("test")
 		Ω(err).ShouldNot(HaveOccurred())
-		outDir, err = ioutil.TempDir(filepath.Join(workspace.Path, "src"), "")
+		outDir, err = os.MkdirTemp(filepath.Join(workspace.Path, "src"), "")
 		Ω(err).ShouldNot(HaveOccurred())
 		os.Args = []string{"goagen", "--out=" + outDir, "--design=foo", "--version=" + version.String()}
 		codegen.TempCount = 0
@@ -61,7 +60,7 @@ var _ = Describe("Generate", func() {
 			Ω(genErr).Should(BeNil())
 			Ω(files).Should(HaveLen(6))
 			isEmptySource := func(filename string) {
-				contextsContent, err := ioutil.ReadFile(filepath.Join(outDir, "app", filename))
+				contextsContent, err := os.ReadFile(filepath.Join(outDir, "app", filename))
 				Ω(err).ShouldNot(HaveOccurred())
 				lines := strings.Split(string(contextsContent), "\n")
 				Ω(lines).ShouldNot(BeEmpty())
@@ -79,7 +78,7 @@ var _ = Describe("Generate", func() {
 		var payload *design.UserTypeDefinition
 
 		isSource := func(filename, content string) {
-			contextsContent, err := ioutil.ReadFile(filepath.Join(outDir, "app", filename))
+			contextsContent, err := os.ReadFile(filepath.Join(outDir, "app", filename))
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(string(contextsContent)).Should(Equal(content))
 		}
@@ -220,7 +219,7 @@ var _ = Describe("Generate", func() {
 			It("generates the correct payload assignment code", func() {
 				Ω(genErr).Should(BeNil())
 
-				contextsContent, err := ioutil.ReadFile(filepath.Join(outDir, "app", "controllers.go"))
+				contextsContent, err := os.ReadFile(filepath.Join(outDir, "app", "controllers.go"))
 				Ω(err).ShouldNot(HaveOccurred())
 				Ω(string(contextsContent)).Should(ContainSubstring(controllersSlicePayloadCode))
 			})
@@ -243,7 +242,7 @@ var _ = Describe("Generate", func() {
 			It("generates the no payloads assignment code", func() {
 				Ω(genErr).Should(BeNil())
 
-				contextsContent, err := ioutil.ReadFile(filepath.Join(outDir, "app", "controllers.go"))
+				contextsContent, err := os.ReadFile(filepath.Join(outDir, "app", "controllers.go"))
 				Ω(err).ShouldNot(HaveOccurred())
 				Ω(string(contextsContent)).Should(ContainSubstring(controllersOptionalPayloadCode))
 			})
@@ -270,7 +269,7 @@ var _ = Describe("Generate", func() {
 			It("generates the corresponding code", func() {
 				Ω(genErr).Should(BeNil())
 
-				contextsContent, err := ioutil.ReadFile(filepath.Join(outDir, "app", "controllers.go"))
+				contextsContent, err := os.ReadFile(filepath.Join(outDir, "app", "controllers.go"))
 				Ω(err).ShouldNot(HaveOccurred())
 				Ω(string(contextsContent)).Should(ContainSubstring(controllersMultipartPayloadCode))
 			})

--- a/goagen/gen_app/test_generator_test.go
+++ b/goagen/gen_app/test_generator_test.go
@@ -1,7 +1,6 @@
 package genapp_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -186,7 +185,7 @@ var _ = Describe("Generate", func() {
 		It("does not call Validate on the resulting media type when it does not exist", func() {
 			Ω(genErr).Should(BeNil())
 			Ω(files).Should(HaveLen(8))
-			content, err := ioutil.ReadFile(filepath.Join(outDir, "app", "test", "foo_testing.go"))
+			content, err := os.ReadFile(filepath.Join(outDir, "app", "test", "foo_testing.go"))
 			Ω(err).ShouldNot(HaveOccurred())
 
 			Ω(content).ShouldNot(ContainSubstring("err = mt.Validate()"))
@@ -195,7 +194,7 @@ var _ = Describe("Generate", func() {
 		It("generates the ActionRouteResponse test methods ", func() {
 			Ω(genErr).Should(BeNil())
 			Ω(files).Should(HaveLen(8))
-			content, err := ioutil.ReadFile(filepath.Join(outDir, "app", "test", "foo_testing.go"))
+			content, err := os.ReadFile(filepath.Join(outDir, "app", "test", "foo_testing.go"))
 			Ω(err).ShouldNot(HaveOccurred())
 
 			Ω(content).Should(ContainSubstring("ShowFooOK("))
@@ -206,7 +205,7 @@ var _ = Describe("Generate", func() {
 		})
 
 		It("generates the route path parameters", func() {
-			content, err := ioutil.ReadFile(filepath.Join(outDir, "app", "test", "foo_testing.go"))
+			content, err := os.ReadFile(filepath.Join(outDir, "app", "test", "foo_testing.go"))
 			Ω(err).ShouldNot(HaveOccurred())
 
 			Ω(content).Should(ContainSubstring(`["param"] = []string{`))
@@ -216,7 +215,7 @@ var _ = Describe("Generate", func() {
 		})
 
 		It("properly handles query parameters", func() {
-			content, err := ioutil.ReadFile(filepath.Join(outDir, "app", "test", "foo_testing.go"))
+			content, err := os.ReadFile(filepath.Join(outDir, "app", "test", "foo_testing.go"))
 			Ω(err).ShouldNot(HaveOccurred())
 
 			Ω(content).Should(ContainSubstring(`if optional != nil`))
@@ -225,7 +224,7 @@ var _ = Describe("Generate", func() {
 		})
 
 		It("properly handles headers", func() {
-			content, err := ioutil.ReadFile(filepath.Join(outDir, "app", "test", "foo_testing.go"))
+			content, err := os.ReadFile(filepath.Join(outDir, "app", "test", "foo_testing.go"))
 			Ω(err).ShouldNot(HaveOccurred())
 
 			Ω(content).Should(ContainSubstring(`if optionalHeader != nil`))
@@ -237,28 +236,28 @@ var _ = Describe("Generate", func() {
 		})
 
 		It("generates calls to new Context ", func() {
-			content, err := ioutil.ReadFile(filepath.Join(outDir, "app", "test", "foo_testing.go"))
+			content, err := os.ReadFile(filepath.Join(outDir, "app", "test", "foo_testing.go"))
 			Ω(err).ShouldNot(HaveOccurred())
 
 			Ω(content).Should(ContainSubstring("app.NewShowFooContext("))
 		})
 
 		It("generates calls controller action method", func() {
-			content, err := ioutil.ReadFile(filepath.Join(outDir, "app", "test", "foo_testing.go"))
+			content, err := os.ReadFile(filepath.Join(outDir, "app", "test", "foo_testing.go"))
 			Ω(err).ShouldNot(HaveOccurred())
 
 			Ω(content).Should(ContainSubstring("ctrl.Show("))
 		})
 
 		It("generates non pointer references to primitive/array/hash payloads", func() {
-			content, err := ioutil.ReadFile(filepath.Join(outDir, "app", "test", "foo_testing.go"))
+			content, err := os.ReadFile(filepath.Join(outDir, "app", "test", "foo_testing.go"))
 			Ω(err).ShouldNot(HaveOccurred())
 
 			Ω(content).Should(ContainSubstring(", payload app.CustomName)"))
 		})
 
 		It("generates header compliant with https://github.com/golang/go/issues/13560", func() {
-			content, err := ioutil.ReadFile(filepath.Join(outDir, "app", "test", "foo_testing.go"))
+			content, err := os.ReadFile(filepath.Join(outDir, "app", "test", "foo_testing.go"))
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(strings.Split(string(content), "\n")).Should(ContainElement(MatchRegexp(`^// Code generated .* DO NOT EDIT\.$`)))
 		})

--- a/goagen/gen_app/writers_test.go
+++ b/goagen/gen_app/writers_test.go
@@ -1,7 +1,6 @@
 package genapp_test
 
 import (
-	"io/ioutil"
 	"os"
 
 	. "github.com/onsi/ginkgo"
@@ -46,7 +45,7 @@ var _ = Describe("ContextsWriter", func() {
 		var f *os.File
 		BeforeEach(func() {
 			dslengine.Reset()
-			f, _ = ioutil.TempFile("", "")
+			f, _ = os.CreateTemp("", "")
 			filename = f.Name()
 		})
 
@@ -90,7 +89,7 @@ var _ = Describe("ContextsWriter", func() {
 				It("writes the simple contexts code", func() {
 					err := writer.Execute(data)
 					Ω(err).ShouldNot(HaveOccurred())
-					b, err := ioutil.ReadFile(filename)
+					b, err := os.ReadFile(filename)
 					Ω(err).ShouldNot(HaveOccurred())
 					written := string(b)
 					Ω(written).ShouldNot(BeEmpty())
@@ -133,7 +132,7 @@ var _ = Describe("ContextsWriter", func() {
 				It("the generated code sets the Content-Type header", func() {
 					err := writer.Execute(data)
 					Ω(err).ShouldNot(HaveOccurred())
-					b, err := ioutil.ReadFile(filename)
+					b, err := os.ReadFile(filename)
 					Ω(err).ShouldNot(HaveOccurred())
 					written := string(b)
 					Ω(written).ShouldNot(BeEmpty())
@@ -174,7 +173,7 @@ var _ = Describe("ContextsWriter", func() {
 				It("the generated code sets the response to an empty collection if value is nil", func() {
 					err := writer.Execute(data)
 					Ω(err).ShouldNot(HaveOccurred())
-					b, err := ioutil.ReadFile(filename)
+					b, err := os.ReadFile(filename)
 					Ω(err).ShouldNot(HaveOccurred())
 					written := string(b)
 					Ω(written).ShouldNot(BeEmpty())
@@ -207,7 +206,7 @@ var _ = Describe("ContextsWriter", func() {
 				It("writes the integer contexts code", func() {
 					err := writer.Execute(data)
 					Ω(err).ShouldNot(HaveOccurred())
-					b, err := ioutil.ReadFile(filename)
+					b, err := os.ReadFile(filename)
 					Ω(err).ShouldNot(HaveOccurred())
 					written := string(b)
 					Ω(written).ShouldNot(BeEmpty())
@@ -223,7 +222,7 @@ var _ = Describe("ContextsWriter", func() {
 					It("writes the integer contexts code", func() {
 						err := writer.Execute(data)
 						Ω(err).ShouldNot(HaveOccurred())
-						b, err := ioutil.ReadFile(filename)
+						b, err := os.ReadFile(filename)
 						Ω(err).ShouldNot(HaveOccurred())
 						written := string(b)
 						Ω(written).ShouldNot(BeEmpty())
@@ -240,7 +239,7 @@ var _ = Describe("ContextsWriter", func() {
 					It("writes the integer contexts code", func() {
 						err := writer.Execute(data)
 						Ω(err).ShouldNot(HaveOccurred())
-						b, err := ioutil.ReadFile(filename)
+						b, err := os.ReadFile(filename)
 						Ω(err).ShouldNot(HaveOccurred())
 						written := string(b)
 						Ω(written).ShouldNot(BeEmpty())
@@ -256,7 +255,7 @@ var _ = Describe("ContextsWriter", func() {
 						It("writes the integer contexts code", func() {
 							err := writer.Execute(data)
 							Ω(err).ShouldNot(HaveOccurred())
-							b, err := ioutil.ReadFile(filename)
+							b, err := os.ReadFile(filename)
 							Ω(err).ShouldNot(HaveOccurred())
 							written := string(b)
 							Ω(written).ShouldNot(BeEmpty())
@@ -289,7 +288,7 @@ var _ = Describe("ContextsWriter", func() {
 				It("writes the string contexts code", func() {
 					err := writer.Execute(data)
 					Ω(err).ShouldNot(HaveOccurred())
-					b, err := ioutil.ReadFile(filename)
+					b, err := os.ReadFile(filename)
 					Ω(err).ShouldNot(HaveOccurred())
 					written := string(b)
 					Ω(written).ShouldNot(BeEmpty())
@@ -305,7 +304,7 @@ var _ = Describe("ContextsWriter", func() {
 					It("writes the string contexts code", func() {
 						err := writer.Execute(data)
 						Ω(err).ShouldNot(HaveOccurred())
-						b, err := ioutil.ReadFile(filename)
+						b, err := os.ReadFile(filename)
 						Ω(err).ShouldNot(HaveOccurred())
 						written := string(b)
 						Ω(written).ShouldNot(BeEmpty())
@@ -322,7 +321,7 @@ var _ = Describe("ContextsWriter", func() {
 					It("writes the String contexts code", func() {
 						err := writer.Execute(data)
 						Ω(err).ShouldNot(HaveOccurred())
-						b, err := ioutil.ReadFile(filename)
+						b, err := os.ReadFile(filename)
 						Ω(err).ShouldNot(HaveOccurred())
 						written := string(b)
 						Ω(written).ShouldNot(BeEmpty())
@@ -338,7 +337,7 @@ var _ = Describe("ContextsWriter", func() {
 						It("writes the integer contexts code", func() {
 							err := writer.Execute(data)
 							Ω(err).ShouldNot(HaveOccurred())
-							b, err := ioutil.ReadFile(filename)
+							b, err := os.ReadFile(filename)
 							Ω(err).ShouldNot(HaveOccurred())
 							written := string(b)
 							Ω(written).ShouldNot(BeEmpty())
@@ -371,7 +370,7 @@ var _ = Describe("ContextsWriter", func() {
 				It("writes the number contexts code", func() {
 					err := writer.Execute(data)
 					Ω(err).ShouldNot(HaveOccurred())
-					b, err := ioutil.ReadFile(filename)
+					b, err := os.ReadFile(filename)
 					Ω(err).ShouldNot(HaveOccurred())
 					written := string(b)
 					Ω(written).ShouldNot(BeEmpty())
@@ -387,7 +386,7 @@ var _ = Describe("ContextsWriter", func() {
 					It("writes the number contexts code", func() {
 						err := writer.Execute(data)
 						Ω(err).ShouldNot(HaveOccurred())
-						b, err := ioutil.ReadFile(filename)
+						b, err := os.ReadFile(filename)
 						Ω(err).ShouldNot(HaveOccurred())
 						written := string(b)
 						Ω(written).ShouldNot(BeEmpty())
@@ -404,7 +403,7 @@ var _ = Describe("ContextsWriter", func() {
 					It("writes the number contexts code", func() {
 						err := writer.Execute(data)
 						Ω(err).ShouldNot(HaveOccurred())
-						b, err := ioutil.ReadFile(filename)
+						b, err := os.ReadFile(filename)
 						Ω(err).ShouldNot(HaveOccurred())
 						written := string(b)
 						Ω(written).ShouldNot(BeEmpty())
@@ -420,7 +419,7 @@ var _ = Describe("ContextsWriter", func() {
 						It("writes the number contexts code", func() {
 							err := writer.Execute(data)
 							Ω(err).ShouldNot(HaveOccurred())
-							b, err := ioutil.ReadFile(filename)
+							b, err := os.ReadFile(filename)
 							Ω(err).ShouldNot(HaveOccurred())
 							written := string(b)
 							Ω(written).ShouldNot(BeEmpty())
@@ -453,7 +452,7 @@ var _ = Describe("ContextsWriter", func() {
 				It("writes the boolean contexts code", func() {
 					err := writer.Execute(data)
 					Ω(err).ShouldNot(HaveOccurred())
-					b, err := ioutil.ReadFile(filename)
+					b, err := os.ReadFile(filename)
 					Ω(err).ShouldNot(HaveOccurred())
 					written := string(b)
 					Ω(written).ShouldNot(BeEmpty())
@@ -469,7 +468,7 @@ var _ = Describe("ContextsWriter", func() {
 					It("writes the boolean contexts code", func() {
 						err := writer.Execute(data)
 						Ω(err).ShouldNot(HaveOccurred())
-						b, err := ioutil.ReadFile(filename)
+						b, err := os.ReadFile(filename)
 						Ω(err).ShouldNot(HaveOccurred())
 						written := string(b)
 						Ω(written).ShouldNot(BeEmpty())
@@ -486,7 +485,7 @@ var _ = Describe("ContextsWriter", func() {
 					It("writes the boolean contexts code", func() {
 						err := writer.Execute(data)
 						Ω(err).ShouldNot(HaveOccurred())
-						b, err := ioutil.ReadFile(filename)
+						b, err := os.ReadFile(filename)
 						Ω(err).ShouldNot(HaveOccurred())
 						written := string(b)
 						Ω(written).ShouldNot(BeEmpty())
@@ -502,7 +501,7 @@ var _ = Describe("ContextsWriter", func() {
 						It("writes the boolean contexts code", func() {
 							err := writer.Execute(data)
 							Ω(err).ShouldNot(HaveOccurred())
-							b, err := ioutil.ReadFile(filename)
+							b, err := os.ReadFile(filename)
 							Ω(err).ShouldNot(HaveOccurred())
 							written := string(b)
 							Ω(written).ShouldNot(BeEmpty())
@@ -535,7 +534,7 @@ var _ = Describe("ContextsWriter", func() {
 				It("writes the array contexts code", func() {
 					err := writer.Execute(data)
 					Ω(err).ShouldNot(HaveOccurred())
-					b, err := ioutil.ReadFile(filename)
+					b, err := os.ReadFile(filename)
 					Ω(err).ShouldNot(HaveOccurred())
 					written := string(b)
 					Ω(written).ShouldNot(BeEmpty())
@@ -552,7 +551,7 @@ var _ = Describe("ContextsWriter", func() {
 					It("writes the array contexts code", func() {
 						err := writer.Execute(data)
 						Ω(err).ShouldNot(HaveOccurred())
-						b, err := ioutil.ReadFile(filename)
+						b, err := os.ReadFile(filename)
 						Ω(err).ShouldNot(HaveOccurred())
 						written := string(b)
 						Ω(written).ShouldNot(BeEmpty())
@@ -568,7 +567,7 @@ var _ = Describe("ContextsWriter", func() {
 					It("writes the array contexts code", func() {
 						err := writer.Execute(data)
 						Ω(err).ShouldNot(HaveOccurred())
-						b, err := ioutil.ReadFile(filename)
+						b, err := os.ReadFile(filename)
 						Ω(err).ShouldNot(HaveOccurred())
 						written := string(b)
 						Ω(written).ShouldNot(BeEmpty())
@@ -585,7 +584,7 @@ var _ = Describe("ContextsWriter", func() {
 					It("writes the array contexts code", func() {
 						err := writer.Execute(data)
 						Ω(err).ShouldNot(HaveOccurred())
-						b, err := ioutil.ReadFile(filename)
+						b, err := os.ReadFile(filename)
 						Ω(err).ShouldNot(HaveOccurred())
 						written := string(b)
 						Ω(written).ShouldNot(BeEmpty())
@@ -601,7 +600,7 @@ var _ = Describe("ContextsWriter", func() {
 						It("writes the array contexts code", func() {
 							err := writer.Execute(data)
 							Ω(err).ShouldNot(HaveOccurred())
-							b, err := ioutil.ReadFile(filename)
+							b, err := os.ReadFile(filename)
 							Ω(err).ShouldNot(HaveOccurred())
 							written := string(b)
 							Ω(written).ShouldNot(BeEmpty())
@@ -634,7 +633,7 @@ var _ = Describe("ContextsWriter", func() {
 				It("writes the array contexts code", func() {
 					err := writer.Execute(data)
 					Ω(err).ShouldNot(HaveOccurred())
-					b, err := ioutil.ReadFile(filename)
+					b, err := os.ReadFile(filename)
 					Ω(err).ShouldNot(HaveOccurred())
 					written := string(b)
 					Ω(written).ShouldNot(BeEmpty())
@@ -650,7 +649,7 @@ var _ = Describe("ContextsWriter", func() {
 					It("writes the array contexts code", func() {
 						err := writer.Execute(data)
 						Ω(err).ShouldNot(HaveOccurred())
-						b, err := ioutil.ReadFile(filename)
+						b, err := os.ReadFile(filename)
 						Ω(err).ShouldNot(HaveOccurred())
 						written := string(b)
 						Ω(written).ShouldNot(BeEmpty())
@@ -667,7 +666,7 @@ var _ = Describe("ContextsWriter", func() {
 					It("writes the array contexts code", func() {
 						err := writer.Execute(data)
 						Ω(err).ShouldNot(HaveOccurred())
-						b, err := ioutil.ReadFile(filename)
+						b, err := os.ReadFile(filename)
 						Ω(err).ShouldNot(HaveOccurred())
 						written := string(b)
 						Ω(written).ShouldNot(BeEmpty())
@@ -683,7 +682,7 @@ var _ = Describe("ContextsWriter", func() {
 						It("writes the array contexts code", func() {
 							err := writer.Execute(data)
 							Ω(err).ShouldNot(HaveOccurred())
-							b, err := ioutil.ReadFile(filename)
+							b, err := os.ReadFile(filename)
 							Ω(err).ShouldNot(HaveOccurred())
 							written := string(b)
 							Ω(written).ShouldNot(BeEmpty())
@@ -708,7 +707,7 @@ var _ = Describe("ContextsWriter", func() {
 				It("writes the contexts code", func() {
 					err := writer.Execute(data)
 					Ω(err).ShouldNot(HaveOccurred())
-					b, err := ioutil.ReadFile(filename)
+					b, err := os.ReadFile(filename)
 					Ω(err).ShouldNot(HaveOccurred())
 					written := string(b)
 					Ω(written).ShouldNot(BeEmpty())
@@ -735,7 +734,7 @@ var _ = Describe("ContextsWriter", func() {
 				It("writes the contexts code", func() {
 					err := writer.Execute(data)
 					Ω(err).ShouldNot(HaveOccurred())
-					b, err := ioutil.ReadFile(filename)
+					b, err := os.ReadFile(filename)
 					Ω(err).ShouldNot(HaveOccurred())
 					written := string(b)
 					Ω(written).ShouldNot(BeEmpty())
@@ -763,7 +762,7 @@ var _ = Describe("ContextsWriter", func() {
 				It("writes the contexts code", func() {
 					err := writer.Execute(data)
 					Ω(err).ShouldNot(HaveOccurred())
-					b, err := ioutil.ReadFile(filename)
+					b, err := os.ReadFile(filename)
 					Ω(err).ShouldNot(HaveOccurred())
 					written := string(b)
 					Ω(written).ShouldNot(BeEmpty())
@@ -786,7 +785,7 @@ var _ = Describe("ContextsWriter", func() {
 				It("writes the contexts code", func() {
 					err := writer.Execute(data)
 					Ω(err).ShouldNot(HaveOccurred())
-					b, err := ioutil.ReadFile(filename)
+					b, err := os.ReadFile(filename)
 					Ω(err).ShouldNot(HaveOccurred())
 					written := string(b)
 					Ω(written).ShouldNot(BeEmpty())
@@ -812,7 +811,7 @@ var _ = Describe("ContextsWriter", func() {
 				It("writes the contexts code", func() {
 					err := writer.Execute(data)
 					Ω(err).ShouldNot(HaveOccurred())
-					b, err := ioutil.ReadFile(filename)
+					b, err := os.ReadFile(filename)
 					Ω(err).ShouldNot(HaveOccurred())
 					written := string(b)
 					Ω(written).ShouldNot(BeEmpty())
@@ -833,7 +832,7 @@ var _ = Describe("ContextsWriter", func() {
 				It("writes the contexts code", func() {
 					err := writer.Execute(data)
 					Ω(err).ShouldNot(HaveOccurred())
-					b, err := ioutil.ReadFile(filename)
+					b, err := os.ReadFile(filename)
 					Ω(err).ShouldNot(HaveOccurred())
 					written := string(b)
 					Ω(written).ShouldNot(BeEmpty())
@@ -866,7 +865,7 @@ var _ = Describe("ContextsWriter", func() {
 				It("writes the contexts code", func() {
 					err := writer.Execute(data)
 					Ω(err).ShouldNot(HaveOccurred())
-					b, err := ioutil.ReadFile(filename)
+					b, err := os.ReadFile(filename)
 					Ω(err).ShouldNot(HaveOccurred())
 					written := string(b)
 					Ω(written).ShouldNot(BeEmpty())
@@ -971,7 +970,7 @@ var _ = Describe("ControllersWriter", func() {
 			It("writes the file server code", func() {
 				err := writer.Execute(data)
 				Ω(err).ShouldNot(HaveOccurred())
-				b, err := ioutil.ReadFile(filename)
+				b, err := os.ReadFile(filename)
 				Ω(err).ShouldNot(HaveOccurred())
 				written := string(b)
 				Ω(written).ShouldNot(BeEmpty())
@@ -996,7 +995,7 @@ var _ = Describe("ControllersWriter", func() {
 				It("writes the OPTIONS handler code", func() {
 					err := writer.Execute(data)
 					Ω(err).ShouldNot(HaveOccurred())
-					b, err := ioutil.ReadFile(filename)
+					b, err := os.ReadFile(filename)
 					Ω(err).ShouldNot(HaveOccurred())
 					written := string(b)
 					Ω(written).ShouldNot(BeEmpty())
@@ -1073,7 +1072,7 @@ var _ = Describe("ControllersWriter", func() {
 				It("returns an empty string", func() {
 					err := writer.Execute(data)
 					Ω(err).ShouldNot(HaveOccurred())
-					b, err := ioutil.ReadFile(filename)
+					b, err := os.ReadFile(filename)
 					Ω(err).ShouldNot(HaveOccurred())
 					written := string(b)
 					Ω(written).Should(BeEmpty())
@@ -1091,7 +1090,7 @@ var _ = Describe("ControllersWriter", func() {
 				It("writes the controller code", func() {
 					err := writer.Execute(data)
 					Ω(err).ShouldNot(HaveOccurred())
-					b, err := ioutil.ReadFile(filename)
+					b, err := os.ReadFile(filename)
 					Ω(err).ShouldNot(HaveOccurred())
 					written := string(b)
 					Ω(written).ShouldNot(BeEmpty())
@@ -1124,7 +1123,7 @@ var _ = Describe("ControllersWriter", func() {
 				It("writes the payload unmarshal function", func() {
 					err := writer.Execute(data)
 					Ω(err).ShouldNot(HaveOccurred())
-					b, err := ioutil.ReadFile(filename)
+					b, err := os.ReadFile(filename)
 					Ω(err).ShouldNot(HaveOccurred())
 					written := string(b)
 					Ω(written).Should(ContainSubstring(payloadNoValidationsObjUnmarshal))
@@ -1158,7 +1157,7 @@ var _ = Describe("ControllersWriter", func() {
 				It("writes the payload unmarshal function", func() {
 					err := writer.Execute(data)
 					Ω(err).ShouldNot(HaveOccurred())
-					b, err := ioutil.ReadFile(filename)
+					b, err := os.ReadFile(filename)
 					Ω(err).ShouldNot(HaveOccurred())
 					written := string(b)
 					Ω(written).Should(ContainSubstring(payloadObjUnmarshal))
@@ -1253,7 +1252,7 @@ var _ = Describe("ControllersWriter", func() {
 				It("writes the payload unmarshal function", func() {
 					err := writer.Execute(data)
 					Ω(err).ShouldNot(HaveOccurred())
-					b, err := ioutil.ReadFile(filename)
+					b, err := os.ReadFile(filename)
 					Ω(err).ShouldNot(HaveOccurred())
 					written := string(b)
 					Ω(written).Should(ContainSubstring(payloadMultipartObjUnmarshalID))
@@ -1279,7 +1278,7 @@ var _ = Describe("ControllersWriter", func() {
 				It("writes the controllers code", func() {
 					err := writer.Execute(data)
 					Ω(err).ShouldNot(HaveOccurred())
-					b, err := ioutil.ReadFile(filename)
+					b, err := os.ReadFile(filename)
 					Ω(err).ShouldNot(HaveOccurred())
 					written := string(b)
 					Ω(written).ShouldNot(BeEmpty())
@@ -1313,7 +1312,7 @@ var _ = Describe("ControllersWriter", func() {
 				It("writes the controllers code", func() {
 					err := writer.Execute(data)
 					Ω(err).ShouldNot(HaveOccurred())
-					b, err := ioutil.ReadFile(filename)
+					b, err := os.ReadFile(filename)
 					Ω(err).ShouldNot(HaveOccurred())
 					written := string(b)
 					Ω(written).ShouldNot(BeEmpty())
@@ -1347,7 +1346,7 @@ var _ = Describe("ControllersWriter", func() {
 				It("writes the controller code", func() {
 					err := writer.Execute(data)
 					Ω(err).ShouldNot(HaveOccurred())
-					b, err := ioutil.ReadFile(filename)
+					b, err := os.ReadFile(filename)
 					Ω(err).ShouldNot(HaveOccurred())
 					written := string(b)
 					Ω(written).ShouldNot(BeEmpty())
@@ -1383,7 +1382,7 @@ var _ = Describe("ControllersWriter", func() {
 				It("writes the controller code", func() {
 					err := writer.Execute(data)
 					Ω(err).ShouldNot(HaveOccurred())
-					b, err := ioutil.ReadFile(filename)
+					b, err := os.ReadFile(filename)
 					Ω(err).ShouldNot(HaveOccurred())
 					written := string(b)
 					Ω(written).ShouldNot(BeEmpty())
@@ -1506,7 +1505,7 @@ var _ = Describe("HrefWriter", func() {
 					It("writes the href method", func() {
 						err := writer.Execute(data)
 						Ω(err).ShouldNot(HaveOccurred())
-						b, err := ioutil.ReadFile(filename)
+						b, err := os.ReadFile(filename)
 						Ω(err).ShouldNot(HaveOccurred())
 						written := string(b)
 						Ω(written).ShouldNot(BeEmpty())
@@ -1522,7 +1521,7 @@ var _ = Describe("HrefWriter", func() {
 					It("writes the href method", func() {
 						err := writer.Execute(data)
 						Ω(err).ShouldNot(HaveOccurred())
-						b, err := ioutil.ReadFile(filename)
+						b, err := os.ReadFile(filename)
 						Ω(err).ShouldNot(HaveOccurred())
 						written := string(b)
 						Ω(written).ShouldNot(BeEmpty())
@@ -1599,7 +1598,7 @@ var _ = Describe("UserTypesWriter", func() {
 				It("writes the simple user type code", func() {
 					err := writer.Execute(data)
 					Ω(err).ShouldNot(HaveOccurred())
-					b, err := ioutil.ReadFile(filename)
+					b, err := os.ReadFile(filename)
 					Ω(err).ShouldNot(HaveOccurred())
 					written := string(b)
 					Ω(written).ShouldNot(BeEmpty())
@@ -1641,7 +1640,7 @@ var _ = Describe("UserTypesWriter", func() {
 				It("writes the user type including hash", func() {
 					err := writer.Execute(data)
 					Ω(err).ShouldNot(HaveOccurred())
-					b, err := ioutil.ReadFile(filename)
+					b, err := os.ReadFile(filename)
 					Ω(err).ShouldNot(HaveOccurred())
 					written := string(b)
 					Ω(written).ShouldNot(BeEmpty())

--- a/goagen/gen_client/cli_generator.go
+++ b/goagen/gen_client/cli_generator.go
@@ -29,7 +29,6 @@ func (g *Generator) generateMain(mainFile string, clientPkg, cliPkg string, func
 	imports := []*codegen.ImportSpec{
 		codegen.SimpleImport("encoding/json"),
 		codegen.SimpleImport("fmt"),
-		codegen.SimpleImport("io/ioutil"),
 		codegen.SimpleImport("net/http"),
 		codegen.SimpleImport("os"),
 		codegen.SimpleImport("time"),

--- a/goagen/gen_client/generator.go
+++ b/goagen/gen_client/generator.go
@@ -333,7 +333,6 @@ func (g *Generator) generateResourceClient(pkgDir string, res *design.ResourceDe
 		codegen.SimpleImport("encoding/json"),
 		codegen.SimpleImport("fmt"),
 		codegen.SimpleImport("io"),
-		codegen.SimpleImport("io/ioutil"),
 		codegen.SimpleImport("mime/multipart"),
 		codegen.SimpleImport("net/http"),
 		codegen.SimpleImport("net/url"),
@@ -1045,7 +1044,7 @@ func (c * Client) {{ .Name }}(ctx context.Context, {{ if .DirName }}filename, {{
 	}
 	if resp.StatusCode != 200 {
 		var body string
-		if b, err := ioutil.ReadAll(resp.Body); err != nil {
+		if b, err := io.ReadAll(resp.Body); err != nil {
 			if len(b) > 0 {
 				body = ": "+ string(b)
 			}

--- a/goagen/gen_client/generator_test.go
+++ b/goagen/gen_client/generator_test.go
@@ -3,7 +3,6 @@ package genclient_test
 import (
 	"bytes"
 	"html/template"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -35,7 +34,7 @@ var _ = Describe("Generate", func() {
 		var err error
 		workspace, err = codegen.NewWorkspace("test")
 		Ω(err).ShouldNot(HaveOccurred())
-		outDir, err = ioutil.TempDir(filepath.Join(workspace.Path, "src"), "")
+		outDir, err = os.MkdirTemp(filepath.Join(workspace.Path, "src"), "")
 		Ω(err).ShouldNot(HaveOccurred())
 		os.Args = []string{"goagen", "--out=" + outDir, "--design=foo", "--version=" + version.String()}
 	})
@@ -120,19 +119,19 @@ var _ = Describe("Generate", func() {
 
 		It("generates code generated header", func() {
 			Ω(genErr).Should(BeNil())
-			content, err := ioutil.ReadFile(filepath.Join(outDir, "client", "foo.go"))
+			content, err := os.ReadFile(filepath.Join(outDir, "client", "foo.go"))
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(string(content)).Should(HavePrefix(resourceHeader))
 
-			content, err = ioutil.ReadFile(filepath.Join(outDir, "client", "client.go"))
+			content, err = os.ReadFile(filepath.Join(outDir, "client", "client.go"))
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(string(content)).Should(HavePrefix(clientHeader))
 
-			content, err = ioutil.ReadFile(filepath.Join(outDir, "client", "media_types.go"))
+			content, err = os.ReadFile(filepath.Join(outDir, "client", "media_types.go"))
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(string(content)).Should(HavePrefix(mediaTypesHeader))
 
-			content, err = ioutil.ReadFile(filepath.Join(outDir, "client", "user_types.go"))
+			content, err = os.ReadFile(filepath.Join(outDir, "client", "user_types.go"))
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(string(content)).Should(HavePrefix(userTypesHeader))
 		})
@@ -173,7 +172,7 @@ var _ = Describe("Generate", func() {
 		It("generates header initialization code that compiles", func() {
 			Ω(genErr).Should(BeNil())
 			Ω(files).Should(HaveLen(9))
-			c, err := ioutil.ReadFile(filepath.Join(outDir, "client", "foo.go"))
+			c, err := os.ReadFile(filepath.Join(outDir, "client", "foo.go"))
 			Ω(err).ShouldNot(HaveOccurred())
 			content := string(c)
 			Ω(content).Should(ContainSubstring("header.Set(\"header_name\", tmp3)\n"))
@@ -219,7 +218,7 @@ var _ = Describe("Generate", func() {
 		It("generates path initialization code that uses all defined URL params in proper format", func() {
 			Ω(genErr).Should(BeNil())
 			Ω(files).Should(HaveLen(9))
-			c, err := ioutil.ReadFile(filepath.Join(outDir, "client", "foo.go"))
+			c, err := os.ReadFile(filepath.Join(outDir, "client", "foo.go"))
 			Ω(err).ShouldNot(HaveOccurred())
 			content := string(c)
 			Ω(content).Should(ContainSubstring("func ShowFooPath("))
@@ -275,7 +274,7 @@ var _ = Describe("Generate", func() {
 		It("generates param initialization code that uses the param name given in the design", func() {
 			Ω(genErr).Should(BeNil())
 			Ω(files).Should(HaveLen(9))
-			c, err := ioutil.ReadFile(filepath.Join(outDir, "client", "foo.go"))
+			c, err := os.ReadFile(filepath.Join(outDir, "client", "foo.go"))
 			Ω(err).ShouldNot(HaveOccurred())
 			content := string(c)
 			Ω(content).Should(ContainSubstring("func ShowFooPath("))
@@ -346,7 +345,7 @@ var _ = Describe("Generate", func() {
 		It("generates param initialization code that uses the param name given in the design", func() {
 			Ω(genErr).Should(BeNil())
 			Ω(files).Should(HaveLen(9))
-			c, err := ioutil.ReadFile(filepath.Join(outDir, "client", "foo.go"))
+			c, err := os.ReadFile(filepath.Join(outDir, "client", "foo.go"))
 			Ω(err).ShouldNot(HaveOccurred())
 			content := string(c)
 			Ω(content).Should(ContainSubstring("func ShowFooPath("))
@@ -417,7 +416,7 @@ var _ = Describe("Generate", func() {
 		It("generates Path function with unique names", func() {
 			Ω(genErr).Should(BeNil())
 			Ω(files).Should(HaveLen(9))
-			content, err := ioutil.ReadFile(filepath.Join(outDir, "client", "foo.go"))
+			content, err := os.ReadFile(filepath.Join(outDir, "client", "foo.go"))
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(content).Should(ContainSubstring("func ShowFooPath("))
 			Ω(strings.Count(string(content), "func ShowFooPath(")).Should(Equal(1))
@@ -440,7 +439,7 @@ var _ = Describe("Generate", func() {
 			It("generates a Download function", func() {
 				Ω(genErr).Should(BeNil())
 				Ω(files).Should(HaveLen(9))
-				content, err := ioutil.ReadFile(filepath.Join(outDir, "client", "foo.go"))
+				content, err := os.ReadFile(filepath.Join(outDir, "client", "foo.go"))
 				Ω(err).ShouldNot(HaveOccurred())
 				Ω(content).Should(ContainSubstring("func (c *Client) DownloadSwaggerJSON("))
 			})
@@ -499,7 +498,7 @@ var _ = Describe("Generate", func() {
 		It("generates the correct client Fields", func() {
 			Ω(genErr).Should(BeNil())
 			Ω(files).Should(HaveLen(9))
-			content, err := ioutil.ReadFile(filepath.Join(outDir, "client", "client.go"))
+			content, err := os.ReadFile(filepath.Join(outDir, "client", "client.go"))
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(content).Should(ContainSubstring("JWT1Signer goaclient.Signer"))
 			Ω(content).Should(ContainSubstring("func (c *Client) SetJWT1Signer(signer goaclient.Signer) {\n	c.JWT1Signer = signer\n}"))
@@ -508,7 +507,7 @@ var _ = Describe("Generate", func() {
 		It("generates the Signer.Sign call from Action", func() {
 			Ω(genErr).Should(BeNil())
 			Ω(files).Should(HaveLen(9))
-			content, err := ioutil.ReadFile(filepath.Join(outDir, "client", "foo.go"))
+			content, err := os.ReadFile(filepath.Join(outDir, "client", "foo.go"))
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(content).Should(ContainSubstring(`		if err := c.JWT1Signer.Sign(req); err != nil {
 			return nil, err
@@ -564,7 +563,7 @@ var _ = Describe("Generate", func() {
 		It("generates the user type imports", func() {
 			Ω(genErr).Should(BeNil())
 			Ω(files).Should(HaveLen(9))
-			content, err := ioutil.ReadFile(filepath.Join(outDir, "client", "user_types.go"))
+			content, err := os.ReadFile(filepath.Join(outDir, "client", "user_types.go"))
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(content).Should(ContainSubstring("uuid \"github.com/shogo82148/goa-v1/uuid\""))
 		})
@@ -627,7 +626,7 @@ var _ = Describe("Generate", func() {
 		It("treat non-required param as pointer type", func() {
 			Ω(genErr).Should(BeNil())
 			Ω(files).Should(HaveLen(9))
-			content, err := ioutil.ReadFile(filepath.Join(outDir, "client", "foo.go"))
+			content, err := os.ReadFile(filepath.Join(outDir, "client", "foo.go"))
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(string(content)).Should(ContainSubstring("if payload.Param != nil"))
 			Ω(string(content)).Should(ContainSubstring("if payload.Image != nil"))
@@ -681,7 +680,7 @@ var _ = Describe("Generate", func() {
 		It("generates param initialization code that uses the param name given in the design", func() {
 			Ω(genErr).Should(BeNil())
 			Ω(files).Should(HaveLen(9))
-			c, err := ioutil.ReadFile(filepath.Join(outDir, "client", "foo.go"))
+			c, err := os.ReadFile(filepath.Join(outDir, "client", "foo.go"))
 			Ω(err).ShouldNot(HaveOccurred())
 			content := string(c)
 			Ω(string(content)).Should(ContainSubstring("ShowFoo(ctx context.Context, path string, metaFoo *string)"))

--- a/goagen/gen_controller/generator_test.go
+++ b/goagen/gen_controller/generator_test.go
@@ -1,7 +1,6 @@
 package gencontroller_test
 
 import (
-	"io/ioutil"
 	"os"
 
 	. "github.com/onsi/ginkgo"
@@ -28,7 +27,7 @@ var _ = Describe("Generate", func() {
 		var err error
 		workspace, err = codegen.NewWorkspace("test")
 		Ω(err).ShouldNot(HaveOccurred())
-		outDir, err = ioutil.TempDir(workspace.Path, "")
+		outDir, err = os.MkdirTemp(workspace.Path, "")
 		Ω(err).ShouldNot(HaveOccurred())
 		os.Args = []string{"goagen", "--out=" + outDir, "--design=foo", "--version=" + version.String()}
 	})

--- a/goagen/gen_js/generator.go
+++ b/goagen/gen_js/generator.go
@@ -3,7 +3,6 @@ package genjs
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -237,7 +236,7 @@ func (g *Generator) generateIndexHTML(htmlFile string, exampleAction *design.Act
 
 func (g *Generator) generateAxiosJS() error {
 	filePath := filepath.Join(g.OutDir, "axios.min.js")
-	if err := ioutil.WriteFile(filePath, []byte(axios), 0644); err != nil {
+	if err := os.WriteFile(filePath, []byte(axios), 0644); err != nil {
 		return err
 	}
 	g.genfiles = append(g.genfiles, filePath)

--- a/goagen/gen_js/generator_test.go
+++ b/goagen/gen_js/generator_test.go
@@ -2,7 +2,6 @@ package genjs_test
 
 import (
 	"go/build"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -51,7 +50,7 @@ var _ = Describe("Generate", func() {
 		It("generates a dummy js", func() {
 			Ω(genErr).Should(BeNil())
 			Ω(files).Should(HaveLen(3))
-			content, err := ioutil.ReadFile(filepath.Join(outDir, "js", "client.js"))
+			content, err := os.ReadFile(filepath.Join(outDir, "js", "client.js"))
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(len(strings.Split(string(content), "\n"))).Should(BeNumerically(">=", 13))
 		})
@@ -95,7 +94,7 @@ var _ = Describe("Generate", func() {
 		It("generates an example HTML", func() {
 			Ω(genErr).Should(BeNil())
 			Ω(files).Should(HaveLen(5))
-			content, err := ioutil.ReadFile(filepath.Join(outDir, "js", "index.html"))
+			content, err := os.ReadFile(filepath.Join(outDir, "js", "index.html"))
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(len(strings.Split(string(content), "\n"))).Should(BeNumerically(">=", 13))
 		})

--- a/goagen/gen_main/generator_test.go
+++ b/goagen/gen_main/generator_test.go
@@ -2,7 +2,6 @@ package genmain_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -86,7 +85,7 @@ var _ = Describe("Generate", func() {
 		It("generates controllers ready for regeneration", func() {
 			Ω(genErr).Should(BeNil())
 			Ω(files).Should(HaveLen(2))
-			content, err := ioutil.ReadFile(filepath.Join(outDir, "first.go"))
+			content, err := os.ReadFile(filepath.Join(outDir, "first.go"))
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(content).Should(MatchRegexp("FirstController_Alpha: start_implement"))
 			Ω(content).Should(MatchRegexp(`// FirstController_Alpha: start_implement\s*// Put your logic here\s*return nil\s*// FirstController_Alpha: end_implement`))
@@ -98,7 +97,7 @@ var _ = Describe("Generate", func() {
 				files, genErr = genmain.Generate()
 
 				// Put some impl in the existing controller
-				existing, err := ioutil.ReadFile(filepath.Join(outDir, "first.go"))
+				existing, err := os.ReadFile(filepath.Join(outDir, "first.go"))
 				Ω(err).ShouldNot(HaveOccurred())
 
 				// First add an import for fmt, to make sure it remains
@@ -107,7 +106,7 @@ var _ = Describe("Generate", func() {
 				// Next add some body that uses fmt
 				existing = bytes.Replace(existing, []byte("// Put your logic here"), []byte("fmt.Println(\"I did it first\")"), 1)
 
-				err = ioutil.WriteFile(filepath.Join(outDir, "first.go"), existing, os.ModePerm)
+				err = os.WriteFile(filepath.Join(outDir, "first.go"), existing, os.ModePerm)
 				Ω(err).ShouldNot(HaveOccurred())
 
 				// Add an action to the existing resource
@@ -144,14 +143,14 @@ var _ = Describe("Generate", func() {
 				Ω(files).Should(HaveLen(2))
 				Ω(files).Should(ConsistOf(filepath.Join(outDir, "first.go"), filepath.Join(outDir, "second.go")))
 
-				content, err := ioutil.ReadFile(filepath.Join(outDir, "second.go"))
+				content, err := os.ReadFile(filepath.Join(outDir, "second.go"))
 				Ω(err).ShouldNot(HaveOccurred())
 				Ω(content).Should(ContainSubstring("SecondController_Gamma: start_implement"))
 
 			})
 
 			It("regenerates controllers without modifying existing impls", func() {
-				content, err := ioutil.ReadFile(filepath.Join(outDir, "first.go"))
+				content, err := os.ReadFile(filepath.Join(outDir, "first.go"))
 				Ω(err).ShouldNot(HaveOccurred())
 
 				// First make sure the new controller is in place

--- a/goagen/gen_schema/generator.go
+++ b/goagen/gen_schema/generator.go
@@ -3,7 +3,6 @@ package genschema
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -73,7 +72,7 @@ func (g *Generator) Generate() (_ []string, err error) {
 	os.MkdirAll(g.OutDir, 0755)
 	g.genfiles = append(g.genfiles, g.OutDir)
 	schemaFile := filepath.Join(g.OutDir, "schema.json")
-	if err = ioutil.WriteFile(schemaFile, js, 0644); err != nil {
+	if err = os.WriteFile(schemaFile, js, 0644); err != nil {
 		return
 	}
 	g.genfiles = append(g.genfiles, schemaFile)

--- a/goagen/gen_schema/generator_test.go
+++ b/goagen/gen_schema/generator_test.go
@@ -2,7 +2,6 @@ package genschema_test
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -53,7 +52,7 @@ var _ = Describe("Generate", func() {
 		It("generates a dummy schema", func() {
 			Ω(genErr).Should(BeNil())
 			Ω(files).Should(HaveLen(2))
-			content, err := ioutil.ReadFile(filepath.Join(testPkg.Abs(), "schema", "schema.json"))
+			content, err := os.ReadFile(filepath.Join(testPkg.Abs(), "schema", "schema.json"))
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(len(strings.Split(string(content), "\n"))).Should(BeNumerically("==", 1))
 			var s genschema.JSONSchema

--- a/goagen/gen_swagger/generator.go
+++ b/goagen/gen_swagger/generator.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -93,7 +92,7 @@ func (g *Generator) Generate() (_ []string, err error) {
 		return nil, err
 	}
 	swaggerFile := filepath.Join(swaggerDir, "swagger.json")
-	if err := ioutil.WriteFile(swaggerFile, rawJSON, 0644); err != nil {
+	if err := os.WriteFile(swaggerFile, rawJSON, 0644); err != nil {
 		return nil, err
 	}
 	g.genfiles = append(g.genfiles, swaggerFile)
@@ -104,7 +103,7 @@ func (g *Generator) Generate() (_ []string, err error) {
 		return nil, err
 	}
 	swaggerFile = filepath.Join(swaggerDir, "swagger.yaml")
-	if err := ioutil.WriteFile(swaggerFile, rawYAML, 0644); err != nil {
+	if err := os.WriteFile(swaggerFile, rawYAML, 0644); err != nil {
 		return nil, err
 	}
 	g.genfiles = append(g.genfiles, swaggerFile)

--- a/goagen/meta/generator.go
+++ b/goagen/meta/generator.go
@@ -2,7 +2,6 @@ package meta
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -99,7 +98,7 @@ func (m *Generator) Generate() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	tmpDir, err := ioutil.TempDir(wd, "goagen")
+	tmpDir, err := os.MkdirTemp(wd, "goagen")
 	if err != nil {
 		if _, ok := err.(*os.PathError); ok {
 			err = fmt.Errorf(`invalid output directory path "%s"`, m.OutDir)

--- a/middleware/gzip/middleware.go
+++ b/middleware/gzip/middleware.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -265,7 +265,7 @@ func Middleware(level int, o ...Option) goa.Middleware {
 	}
 	gzipPool := sync.Pool{
 		New: func() interface{} {
-			gz, err := gzip.NewWriterLevel(ioutil.Discard, level)
+			gz, err := gzip.NewWriterLevel(io.Discard, level)
 			if err != nil {
 				panic(err)
 			}

--- a/mux_test.go
+++ b/mux_test.go
@@ -2,7 +2,7 @@ package goa_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -51,7 +51,7 @@ var _ = Describe("Mux", func() {
 			req, err = http.NewRequest(reqMeth, reqPath, &body)
 			Ω(err).ShouldNot(HaveOccurred())
 			mux.Handle(reqMeth, reqPath, func(rw http.ResponseWriter, req *http.Request, vals url.Values) {
-				b, err := ioutil.ReadAll(req.Body)
+				b, err := io.ReadAll(req.Body)
 				Ω(err).ShouldNot(HaveOccurred())
 				readPath = req.URL.Path
 				readMeth = req.Method

--- a/service_test.go
+++ b/service_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"sync"
@@ -118,7 +118,7 @@ var _ = Describe("Service", func() {
 			ctrl := s.NewController("test")
 			ctrl.MaxRequestBodyLength = 4
 			unmarshaler := func(ctx context.Context, service *goa.Service, req *http.Request) error {
-				_, err := ioutil.ReadAll(req.Body)
+				_, err := io.ReadAll(req.Body)
 				return err
 			}
 			handler := func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
@@ -254,7 +254,7 @@ var _ = Describe("Service", func() {
 
 			Context("with an invalid payload", func() {
 				BeforeEach(func() {
-					r.Body = ioutil.NopCloser(bytes.NewBuffer([]byte("not json")))
+					r.Body = io.NopCloser(bytes.NewBuffer([]byte("not json")))
 					r.ContentLength = 8
 				})
 
@@ -329,7 +329,7 @@ var _ = Describe("Service", func() {
 
 				BeforeEach(func() {
 					r.Header.Set("Content-Type", "application/json")
-					r.Body = ioutil.NopCloser(bytes.NewReader(content))
+					r.Body = io.NopCloser(bytes.NewReader(content))
 					r.ContentLength = int64(len(content))
 				})
 


### PR DESCRIPTION
goagen still generate the code that uses the `io/ioutil` package.
this pull request removes it.

https://pkg.go.dev/io/ioutil

> As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details.