### PR TITLE
fix short id generator

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -194,7 +194,9 @@ func drainBody(b io.ReadCloser) (r1, r2 io.ReadCloser, err error) {
 // Do not use as a reliable way to get unique IDs, instead use for things like logging.
 func shortID() string {
 	b := make([]byte, 6)
-	io.ReadFull(rand.Reader, b)
+	if _, err := io.ReadFull(rand.Reader, b); err != nil {
+		panic(err)
+	}
 	return base64.StdEncoding.EncodeToString(b)
 }
 

--- a/error.go
+++ b/error.go
@@ -359,6 +359,8 @@ func asErrorResponse(err error) *ErrorResponse {
 // are not catastrophic.
 func newErrorID() string {
 	b := make([]byte, 6)
-	io.ReadFull(rand.Reader, b)
+	if _, err := io.ReadFull(rand.Reader, b); err != nil {
+		panic(err)
+	}
 	return base64.StdEncoding.EncodeToString(b)
 }

--- a/middleware/log_request.go
+++ b/middleware/log_request.go
@@ -112,7 +112,9 @@ func LogRequest(verbose bool, sensitiveHeaders ...string) goa.Middleware {
 // Do not use as a reliable way to get unique IDs, instead use for things like logging.
 func shortID() string {
 	b := make([]byte, 6)
-	io.ReadFull(rand.Reader, b)
+	if _, err := io.ReadFull(rand.Reader, b); err != nil {
+		panic(err)
+	}
 	return base64.StdEncoding.EncodeToString(b)
 }
 

--- a/middleware/request_id.go
+++ b/middleware/request_id.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"sync/atomic"
@@ -31,10 +32,13 @@ func init() {
 	// algorithm taken from https://github.com/zenazn/goji/blob/master/web/middleware/request_id.go#L44-L50
 	var buf [12]byte
 	var b64 string
+	replacer := strings.NewReplacer("+", "", "/", "")
 	for len(b64) < 10 {
-		rand.Read(buf[:])
+		if _, err := io.ReadFull(rand.Reader, buf[:]); err != nil {
+			panic(err)
+		}
 		b64 = base64.StdEncoding.EncodeToString(buf[:])
-		b64 = strings.NewReplacer("+", "", "/", "").Replace(b64)
+		b64 = replacer.Replace(b64)
 	}
 	reqPrefix = string(b64[0:10])
 }

--- a/middleware/xray/middleware.go
+++ b/middleware/xray/middleware.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"sync"
@@ -107,7 +108,7 @@ func New(service, daemon string) (goa.Middleware, error) {
 // compatible with AWS X-Ray.
 func NewID() string {
 	b := make([]byte, 8)
-	if _, err := rand.Read(b); err != nil {
+	if _, err := io.ReadFull(rand.Reader, b); err != nil {
 		panic(err)
 	}
 	return fmt.Sprintf("%x", b)
@@ -117,7 +118,7 @@ func NewID() string {
 // compatible with AWS X-Ray.
 func NewTraceID() string {
 	b := make([]byte, 12)
-	if _, err := rand.Read(b); err != nil {
+	if _, err := io.ReadFull(rand.Reader, b); err != nil {
 		panic(err)
 	}
 	return fmt.Sprintf("%d-%x-%s", 1, time.Now().Unix(), fmt.Sprintf("%x", b))


### PR DESCRIPTION
`rand.Read(buf)` is used in some places, but it doesn't guarantee to fill `buf`.
`io.ReadFull(rand.Reader, buf)` should be used instead of it.
