### PR TITLE
TInterface is now deprecated

### DIFF
--- a/goagen/gen_app/test_generator.go
+++ b/goagen/gen_app/test_generator.go
@@ -91,6 +91,7 @@ func (g *Generator) generateResourceTest() error {
 		codegen.SimpleImport("net/url"),
 		codegen.SimpleImport("strconv"),
 		codegen.SimpleImport("strings"),
+		codegen.SimpleImport("testing"),
 		codegen.SimpleImport("time"),
 		codegen.SimpleImport(appPkg),
 		codegen.NewImport("goa", "github.com/shogo82148/goa-v1"),
@@ -360,7 +361,7 @@ var testTmpl = `{{ define "convertParam" }}` + convertParamTmpl + `{{ end }}` + 
 // {{ $test.Name }} {{ $test.Comment }}
 // If ctx is nil then context.Background() is used.
 // If service is nil then a default service is created.
-func {{ $test.Name }}(t goatest.TInterface, ctx context.Context, service *goa.Service, ctrl {{ $test.ControllerName}}{{/*
+func {{ $test.Name }}(t testing.TB, ctx context.Context, service *goa.Service, ctrl {{ $test.ControllerName}}{{/*
 */}}{{ range $param := $test.Params }}, {{ $param.Name }} {{ $param.Pointer }}{{ $param.Type }}{{ end }}{{/*
 */}}{{ range $param := $test.QueryParams }}, {{ $param.Name }} {{ $param.Pointer }}{{ $param.Type }}{{ end }}{{/*
 */}}{{ range $header := $test.Headers }}, {{ $header.Name }} {{ $header.Pointer }}{{ $header.Type }}{{ end }}{{/*

--- a/goagen/gen_app/test_generator_test.go
+++ b/goagen/gen_app/test_generator_test.go
@@ -201,7 +201,7 @@ var _ = Describe("Generate", func() {
 			// Multiple Routes
 			Ω(content).Should(ContainSubstring("ShowFooOK1("))
 			// Get returns an error media type
-			Ω(content).Should(ContainSubstring("GetFooOK(t goatest.TInterface, ctx context.Context, service *goa.Service, ctrl app.FooController, optionalResourceHeader *int, requiredResourceHeader string, payload app.CustomName) (http.ResponseWriter, error)"))
+			Ω(content).Should(ContainSubstring("GetFooOK(t testing.TB, ctx context.Context, service *goa.Service, ctrl app.FooController, optionalResourceHeader *int, requiredResourceHeader string, payload app.CustomName) (http.ResponseWriter, error)"))
 		})
 
 		It("generates the route path parameters", func() {

--- a/goatest/testing.go
+++ b/goatest/testing.go
@@ -11,7 +11,7 @@ import (
 
 // TInterface is an interface for Go's testing.T and testing.B.
 //
-// It is an alias of testing.TB.
+// Deprecated: use testing.TB instead.
 type TInterface = testing.TB
 
 // ResponseSetterFunc func


### PR DESCRIPTION
TInterface is just an alias of [testing.TB](https://pkg.go.dev/testing#TB).
There is no meaning to use TInterface.
Users should use testing.TB directly.