### PR TITLE
Fixed auto-generated code when default value is set for DateTime type

### DIFF
--- a/_integration_tests/default-value/design/design.go
+++ b/_integration_tests/default-value/design/design.go
@@ -1,0 +1,26 @@
+package design
+
+import (
+	"time"
+
+	. "github.com/shogo82148/goa-v1/design"
+	. "github.com/shogo82148/goa-v1/design/apidsl"
+)
+
+var _ = API("default-time", func() {
+	Title("This API has time.Time default values")
+	Host("localhost:8080")
+	Scheme("https")
+})
+
+var _ = Resource("timetest", func() {
+	Action("check", func() {
+		Routing(GET("/"))
+		Params(func() {
+			Param("times", DateTime, func() {
+				Default(time.Time{}.Format(time.RFC3339))
+			})
+		})
+		Response(OK)
+	})
+})

--- a/_integration_tests/integration_test.go
+++ b/_integration_tests/integration_test.go
@@ -47,7 +47,7 @@ type CreateGreetingPayload struct {
 }
 
 func TestDefaultTime(t *testing.T) {
-	//defer cleanup("./default-value/*")
+	defer cleanup("./default-value/*")
 	if err := goagen("./default-value", "bootstrap", "-d", "github.com/shogo82148/goa-v1/_integration_tests/default-value/design"); err != nil {
 		t.Error(err.Error())
 	}

--- a/_integration_tests/integration_test.go
+++ b/_integration_tests/integration_test.go
@@ -46,6 +46,43 @@ type CreateGreetingPayload struct {
 	}
 }
 
+func TestDefaultTime(t *testing.T) {
+	//defer cleanup("./default-value/*")
+	if err := goagen("./default-value", "bootstrap", "-d", "github.com/shogo82148/goa-v1/_integration_tests/default-value/design"); err != nil {
+		t.Error(err.Error())
+	}
+	if err := gobuild("./default-value"); err != nil {
+		t.Error(err.Error())
+	}
+	b, err := os.ReadFile("./default-value/app/contexts.go")
+	if err != nil {
+		t.Fatal("failed to load contexts.go")
+	}
+	expected := `func NewCheckTimetestContext(ctx context.Context, r *http.Request, service *goa.Service) (*CheckTimetestContext, error) {
+	var err error
+	resp := goa.ContextResponse(ctx)
+	resp.Service = service
+	req := goa.ContextRequest(ctx)
+	req.Request = r
+	rctx := CheckTimetestContext{Context: ctx, ResponseData: resp, RequestData: req}
+	paramTimes := req.Params["times"]
+	if len(paramTimes) == 0 {
+		rctx.Times, err = time.Parse(time.RFC3339, "0001-01-01T00:00:00Z")
+	} else {
+		rawTimes := paramTimes[0]
+		if times, err2 := time.Parse(time.RFC3339, rawTimes); err2 == nil {
+			rctx.Times = times
+		} else {
+			err = goa.MergeErrors(err, goa.InvalidParamTypeError("times", rawTimes, "datetime"))
+		}
+	}
+	return &rctx, err
+}`
+	if !strings.Contains(string(b), expected) {
+		t.Errorf("Default time attribute definitions reference failed. Generated context:\n%s", string(b))
+	}
+}
+
 func TestCellar(t *testing.T) {
 	defer cleanup("./goa-cellar/*")
 	if err := goagen("./goa-cellar", "bootstrap", "-d", "github.com/shogo82148/goa-v1/_integration_tests/goa-cellar/design"); err != nil {

--- a/goagen/gen_app/writers.go
+++ b/goagen/gen_app/writers.go
@@ -471,6 +471,8 @@ func valueTypeOf(prefix string, att *design.AttributeDefinition) string {
 		return prefix + "float"
 	case design.StringKind:
 		return prefix + "string"
+	case design.DateTimeKind:
+		return prefix + "time.Time"
 	case design.ArrayKind:
 		return valueTypeOf(prefix+"[]", arrayAttribute(att))
 	case design.HashKind:
@@ -644,7 +646,7 @@ func New{{ .Name }}(ctx context.Context, r *http.Request, service *goa.Service) 
 */}}err = goa.MergeErrors(err, goa.MissingParamError("{{ $name }}")){{end}}
 	} else {
 {{ else }}{{ if $.Params.HasDefaultValue $name }}	if len(param{{ goifyatt $att $name true }}) == 0 {
-		{{printf "rctx.%s" (goifyatt $att $name true) }} = {{ printVal $att.Type $att.DefaultValue }}
+{{ if eq (valueTypeOf "" $att ) "time.Time" }}		{{printf "rctx.%s, err" (goifyatt $att $name true)}} = {{ printVal $att.Type $att.DefaultValue }}{{ else }}		{{printf "rctx.%s" (goifyatt $att $name true) }} = {{ printVal $att.Type $att.DefaultValue }}{{ end }}
 	} else {
 {{ else }}	if len(param{{ goifyatt $att $name true }}) > 0 {
 {{ end }}{{ end }}{{/* if $mustValidate */}}{{ if $att.Type.IsArray }}{{ if eq (arrayAttribute $att).Type.Kind 4 }}		params := param{{ goifyatt $att $name true }}


### PR DESCRIPTION
There is an bug in the auto-generated code when a default value is set for the DateTime type. 
I fix this bug.

## Current behavior
When automatic generation is executed for the following design files.
```go
Param("before", DateTime, func() {
	Default(time.Time{}.Format(time.RFC3339))
})
```

Genererate code
```go
if len(paramBefore) == 0 {
	rctx.After = time.Parse(time.RFC3339, "0001-01-01T00:00:00Z") // This code does not handle error, so it's broken code.
}
```

## Fix version
```go
if len(paramBefore) == 0 {
	rctx.After, err = time.Parse(time.RFC3339, "0001-01-01T00:00:00Z") // Add error handling
}
```
