### PR TITLE
Fix package comment

### DIFF
--- a/logging/slog/adapter.go
+++ b/logging/slog/adapter.go
@@ -6,9 +6,9 @@ Package goaslog contains an adapter that makes it possible to configure goa so i
 as logger backend.
 Usage:
 
-	logger := logrus.New()
-	// Initialize logger handler using logrus package
-	service.WithLogger(goaslog.New(logger))
+	handler := slog.NewJSONHandler(os.Stderr, nil)
+	// Initialize logger handler using [log/slog] package
+	service.WithLogger(goaslog.New(handler))
 	// ... Proceed with configuring and starting the goa service
 
 	// In handlers:


### PR DESCRIPTION
The goaslog package should describe how to initialize loggers using log/slog, but currently it uses logrus.
I fixed it.