### PR TITLE
Fix outputting error logs 

### DIFF
--- a/logging.go
+++ b/logging.go
@@ -162,7 +162,7 @@ func LogError(ctx context.Context, msg string, keyvals ...interface{}) {
 		switch logger := l.(type) {
 		case ContextLogAdapter:
 			logger.ErrorContext(ctx, msg, keyvals...)
-		case WarningLogAdapter:
+		case LogAdapter:
 			logger.Error(msg, keyvals...)
 		}
 	}

--- a/service.go
+++ b/service.go
@@ -215,7 +215,7 @@ func (service *Service) LogError(msg string, keyvals ...interface{}) {
 		switch logger := l.(type) {
 		case ContextLogAdapter:
 			logger.ErrorContext(ctx, msg, keyvals...)
-		case WarningLogAdapter:
+		case LogAdapter:
 			logger.Error(msg, keyvals...)
 		}
 	}


### PR DESCRIPTION
Currently, the LogError function expects that the ContextLogAdapter or WarningLogAdapter interface is implemented, but at least WarningLogAdapter is not a required requirement for this function. When an adapter implements the LogAdapter interface but does not implement the WarningLogAdapter interface, the LogError function will exit without outputting anything.

I fixed this problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Updated the error logging behavior for improved consistency and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->