### PR TITLE
[Bug fix] Issue 301: Metadata() is not reflected when setting the Default() in goa design.

### DIFF
--- a/_integration_tests/issue301/design/design.go
+++ b/_integration_tests/issue301/design/design.go
@@ -1,0 +1,39 @@
+package design
+
+import (
+	. "github.com/shogo82148/goa-v1/design"
+	. "github.com/shogo82148/goa-v1/design/apidsl"
+)
+
+var _ = API("issue301", func() {
+	Title("This API has user definition type default values")
+	Host("localhost:8080")
+	Scheme("https")
+})
+
+var _ = Resource("issue301", func() {
+	Action("test", func() {
+		Routing(GET("user-definition"))
+		Payload(Issue301Payload)
+		Response(OK)
+	})
+})
+
+var Issue301Payload = Type("Issue301Type", func() {
+	Attribute("user-definition-type", Integer, func() {
+		Default(10)
+		Metadata("struct:field:type", "design.SecuritySchemeKind", "github.com/shogo82148/goa-v1/design")
+	})
+
+	Attribute("primitive-type-number", Number, func() {
+		Default(3.14)
+	})
+
+	Attribute("primitive-type-time", DateTime, func() {
+		Default("2006-01-02T15:04:05Z")
+	})
+
+	Required("user-definition-type")
+	Required("primitive-type-number")
+	Required("primitive-type-time")
+})

--- a/goagen/codegen/finalizer.go
+++ b/goagen/codegen/finalizer.go
@@ -25,6 +25,7 @@ func NewFinalizer() *Finalizer {
 		"tabs":         Tabs,
 		"goify":        Goify,
 		"gotyperef":    GoTypeRef,
+		"gotypedef":    GoTypeDef,
 		"add":          Add,
 		"finalizeCode": f.Code,
 	}
@@ -163,7 +164,7 @@ func PrintVal(t design.DataType, val interface{}) string {
 
 const (
 	assignmentTmpl = `{{ if .catt.Type.IsPrimitive }}{{ $defaultName := (print "default" (goify .field true)) }}{{/*
-*/}}{{ tabs .depth }}var {{ $defaultName }}{{if .isDatetime}}, _{{end}} = {{ .defaultVal }}
+*/}}{{ tabs .depth }}{{if .isDatetime}}var {{ $defaultName }}, _ = {{ .defaultVal }}{{ else }}var {{ $defaultName }} {{ gotypedef .catt 0 false false }} = {{ .defaultVal }}{{end}}
 {{ tabs .depth }}if {{ .target }}.{{ goify .field true }} == nil {
 {{ tabs .depth }}	{{ .target }}.{{ goify .field true }} = &{{ $defaultName }}
 }{{ else }}{{ tabs .depth }}if {{ .target }}.{{ goify .field true }} == nil {


### PR DESCRIPTION
The bug details are documented in Issue #301.
I am wrote unit tests and integration tests for the scope of the bug fix.


This PR affects the entire `Finalize()` code generated by goa.
After this PR is merged, type information will always be provided for the local variables generated within Finalize(), like this:

```go
func (ut *issue301Type) Finalize() {
	var defaultPrimitiveTypeNumber float64 = 3.140000
	if ut.PrimitiveTypeNumber == nil {
		ut.PrimitiveTypeNumber = &defaultPrimitiveTypeNumber
	}
	var defaultPrimitiveTypeTime, _ = time.Parse(time.RFC3339, "2006-01-02T15:04:05Z")
	if ut.PrimitiveTypeTime == nil {
		ut.PrimitiveTypeTime = &defaultPrimitiveTypeTime
	}
	var defaultUserDefinitionType design.SecuritySchemeKind = 10
	if ut.UserDefinitionType == nil {
		ut.UserDefinitionType = &defaultUserDefinitionType
	}
}
```

Previously, local variable type information was omitted in `Finalize()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced code generation to automatically set default values for user-defined types.
	- Introduced a new API resource with detailed action definitions and default parameters.
- **Tests**
	- Added integration tests to validate the correct generation of default values in user-defined types.
- **Documentation**
	- Updated API documentation to include new resource details and payload attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->