### PR TITLE
add Go 1.23 to the build matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,8 @@ jobs:
           - "windows-latest"
           - "macos-latest"
         go:
-          - "1"
+          - "stable"
+          - "1.23"
           - "1.22"
           - "1.21"
           - "1.20"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated supported Go versions in the CI/CD workflow to include both the latest stable release and version 1.23, enhancing flexibility and compatibility for testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->