### PR TITLE
drop support of Go 1.22

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,8 @@ jobs:
           - "macos-latest"
         go:
           - "stable"
+          - "1.24"
           - "1.23"
-          - "1.22"
-          - "1.21"
-          - "1.20"
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/shogo82148/goa-v1
 
-go 1.20
+go 1.23.0
 
 require (
 	github.com/ajg/form v1.5.1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Refined the testing setup to ensure coverage with the latest supported versions. This update streamlines our quality checks and improves overall stability.
  
- **Chores**
  - Upgraded the underlying system to a more recent version of Go, enhancing performance and incorporating the latest language improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->