### PR TITLE
update test matrix to include Go versions 1.25, 1.26, and 1.27

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,9 @@ jobs:
           - "macos-latest"
         go:
           - "stable"
+          - "1.27"
+          - "1.26"
+          - "1.25"
           - "1.24"
           - "1.23"
       fail-fast: false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded automated testing to cover Go versions 1.25, 1.26, and 1.27.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->